### PR TITLE
Add missing extend dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
+    "extend": "^3.0.0",
     "google-cloud": "^0.38.3",
     "simple-google-openid": "0.0.5"
   }


### PR DESCRIPTION
Fixes #1 

This fixes the npm moans about a missing package after running
npm install.

Tested with 'extend':'*' and seemed to work fine, so have set the compat
version to the latest release.
