### PR TITLE
Abstract out Google cloud into new file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
+    "extend": "^3.0.0",
     "google-cloud": "^0.38.3",
     "simple-google-openid": "0.0.5"
   }

--- a/server/google.js
+++ b/server/google.js
@@ -1,0 +1,14 @@
+module.exports = {
+  project: function gcloudProject() {
+    gcloud = require('google-cloud')({
+      projectId: 'jacek-soc-port-ac-uk',
+      keyFilename: 'jacek-soc-port-ac-uk-google-key.json',
+    });
+    return gcloud;
+  },
+  datastore: function gcloudDatastore(gcloud, pNamespace){
+    // to use local datastore, add apiEndpoint: 'http://localhost:<port>'
+    datastore = gcloud.datastore({ namespace: pNamespace });
+    return datastore;
+  }
+};

--- a/server/storage-migrate-v1-v2.js
+++ b/server/storage-migrate-v1-v2.js
@@ -4,17 +4,14 @@
 
 'use strict';
 
-const gcloud = require('google-cloud')({
-  projectId: 'jacek-soc-port-ac-uk',
-  keyFilename: 'jacek-soc-port-ac-uk-google-key.json',
-});
+const google = require('./google');
+const gcloud = google.project();
 
 const v1 = 'living-meta-analysis-v1';
 const v2 = 'living-meta-analysis-v2';
 
-const datastorev1 = gcloud.datastore({ namespace: v1 });
-const datastorev2 = gcloud.datastore({ namespace: v2 });
-
+const datastore = google.datastore(gcloud, v1);
+const datastore = google.datastore(gcloud, v2);
 
 // get all users immediately on the start of the server
 migrateAllUsers();

--- a/server/storage.js
+++ b/server/storage.js
@@ -10,12 +10,10 @@
 const tools = require('./tools');
 const ValidationError = require('./errors/ValidationError');
 
-const gcloud = require('google-cloud')({
-  projectId: 'jacek-soc-port-ac-uk',
-  keyFilename: 'jacek-soc-port-ac-uk-google-key.json',
-});
+const google = require('./google');
+const gcloud = google.project();
 
-const datastore = gcloud.datastore({ namespace: 'living-meta-analysis-v2' });
+const datastore = google.datastore(gcloud, 'living-meta-analysis-v2');
 
 const TITLE_RE = module.exports.TITLE_RE = '[a-zA-Z0-9.-]+';
 const TITLE_REXP = new RegExp(`^${TITLE_RE}$`);


### PR DESCRIPTION
PR contains just a single commit which puts all google cloud related parts into google.js.

Doesn't touch the CLIENT_ID used in auth.js. Because this is client side JS rather than server, need to discuss whether it is fine to leave this alone where it is, or if we want to add a rest endpoint for the client to poke to get at it.

It is of my opinion that all hard code values for a particular service should be in one place to make it easier to maintain if we need to change them, but I also feel that a rest endpoint and subsequently a call (which will need to handle retries?) might be overkill considering it is unlikely to change.
