### PR TITLE
Papers: Make links width limited

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -533,6 +533,21 @@ section.list > ul > li > ul.tags > li {
   max-width: 30em;
 }
 
+#paper .link .value {
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: top;
+  max-width: 30em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#paper .link .editing:focus {
+  white-space: pre-line;
+  overflow: visible;
+  text-overflow: unset;
+}
+
 #paper > header {
   background: #ddf;
   margin: 0;


### PR DESCRIPTION
Add CSS rules to limit the width of Paper links.

Editable links have rules to ignore the width limited when focused on
to allow editing.

Non-editable links do not react to user interaction at all, but could
have a :hover event if required.

Solves #6 
