### PR TITLE
Profile: Remove users name prefixing Meta-analysis

### DIFF
--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -319,6 +319,10 @@
     _.fillEls('.fnOrYour', y ? 'Your' : n + "'s");
     _.fillEls('.fnOryou',  y ? 'you'  : n       );
 
+    // Used on profile page, prefixes 'Your ' if you're signed in and the page
+    // is about you. The space is needed for formatting.
+    _.fillEls('.blankOrYour', y ? 'Your ' : '' );
+
     _.findEls('.needs-owner').forEach(function (el) {
       if (el.dataset.owner === currentUser) el.classList.add('yours');
       else                                  el.classList.remove('yours');

--- a/webpages/profile/profile.html
+++ b/webpages/profile/profile.html
@@ -38,7 +38,7 @@
 
 <section class="metaanalysis list">
   <header>
-    <h2><span class="fnOrYour">User's</span> meta-analyses</h2>
+    <h2><span class="blankOrYour"></span>Meta-analyses</h2>
     <div class="filter">Sort/filter
       <ul class="options">
         <li><label><input type="radio" name="metaanalysis-sort" value="modified" checked> recently modified</label></li>


### PR DESCRIPTION
Commit Msg:

```
This is in part to fix a formatting issue, if the name of the user is too
long but also follows the same pattern as Github and provides consistency.

Now when viewing a page which is not about you, it will simply omit any
prefix, and when signed in and on a page about you it will prefix with
'Your '.
```

I've added a new class 'yourOrBlank' which can be used in the future, and I've left the
original code in place, so that it can be used in the future if needed.

Fixes #8 
