### PR TITLE
Links: Add no-referrer to stop link referral

### DIFF
--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -1,4 +1,7 @@
 <!doctype html>
 <title>meta-analysis todo</title>
 
+<!-- Do not send referrer, so Links are followed directly -->
+<meta name="referrer" content="no-referrer">
+
 <h1>meta-analysis todo</h1>

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -5,6 +5,9 @@
 <script src="https://apis.google.com/js/platform.js"></script>
 <link rel="stylesheet" href="/css/main.css">
 
+<!-- Do not send referrer, so Links are followed directly -->
+<meta name="referrer" content="no-referrer">
+
 <body class="loading">
 
 <header>


### PR DESCRIPTION
Add a meta tag for no-referrer to stop links from getting
referred.

Now they should go straight through to the resource
instead of hitting a landing page.

Pre-emptively added to metaanalysis.html as it will likely
suffer the same problem.

More info @ https://w3c.github.io/webappsec-referrer-policy

Fixes #13 
