### PR TITLE
Reference: Formatting same as Description

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -526,6 +526,7 @@ section.list > ul > li > ul.tags > li {
   margin: .5em 16em 0 0;
 }
 
+#paper .reference .value,
 #paper .description .value {
   white-space: pre-line;
   display: inline-block;


### PR DESCRIPTION
Added #paper .reference .value to the CSS rules that defined
the formatting for the description field.

If they need to be subtly different in the future it is easy enough
to split this out but as they are the same for now they share.

Partially fixes #12 
