### PR TITLE
papers: block editing while saving

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -937,6 +937,28 @@ body:not(.page-about-you).signed-on #paper > header .edityourcopy {
   display: none;
 }
 
+.savingspinner { display: none !important; }
+
+#paper.editing-disabled-by-saving ~ .savingspinner {
+  display: block !important;
+  font-size: 200%;
+  font-style: italic;
+  font-weight: normal;
+  position: fixed;
+  padding: 1em;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  background-color: #ddf;
+  border-radius: 1em;
+  box-shadow: 0 0 1em 1em #ddf;
+  color: #646;
+}
+
+#paper.editing-disabled-by-saving { opacity: .5; transition: opacity .3s; }
+
+
 
 /* experiment data
  *

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -1030,6 +1030,7 @@
 
   lima.saveStopped = function saveStopped() {
     _.removeClass('#paper', 'saving');
+    _.removeClass('#paper', 'editing-disabled-by-saving');
   }
 
   lima.saveError = function saveError() {
@@ -1580,8 +1581,19 @@
    *
    *
    */
+  document.addEventListener('keydown', blockWhenSaving, true);
   document.addEventListener('keydown', dismissOrBlurOnEscape);
   document.addEventListener('click', popupOnClick);
+
+  // a keystroke when saving will trigger the "saving..." spinner, and otherwise be ignored
+  function blockWhenSaving(ev) {
+    if (_.isSaving()) {
+      ev.stopImmediatePropagation();
+      ev.stopPropagation();
+      ev.preventDefault();
+      _.addClass('#paper', 'editing-disabled-by-saving');
+    }
+  }
 
   // dismiss pinned popup boxes with Escape or with a click outside them
   function dismissOrBlurOnEscape(ev) {

--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -434,6 +434,10 @@
 
   _.manualSave = doSave;
 
+  _.isSaving = function isSaving() {
+    return !!currentSavingFunction;
+  };
+
   function doSave() {
     if (currentSavingFunction) return;
 

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -299,6 +299,8 @@
   </div>
 </template>
 
+<p class="savingspinner">saving&hellip;</p>
+
 <footer>
   <p>LiMA (Living Meta-Analysis) by <a href="mailto:jacek.kopecky@port.ac.uk">Jacek Kopecky</a> et al. at <a href="http://port.ac.uk/">University of Portsmouth</a>, 2016</p>
 </footer>


### PR DESCRIPTION
While saving, keydown events are ignored – this means it’s unlikely changes will get overridden by a save. If a key is pressed while saving, the page text dims and shows a “saving” message.

To see what it looks like, it might be easiest to do this in the JS console:

```
window.paper.classList.add('editing-disabled-by-saving')
```
