### PR TITLE
Papers: prefix doi: and handle in input

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -548,6 +548,7 @@ section.list > ul > li > ul.tags > li {
   margin-left: -25px;
   padding-left: 25px;
   font-style: normal;
+  display: inline-block;
 }
 
 #paper .link .value {

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -539,6 +539,17 @@ section.list > ul > li > ul.tags > li {
   max-width: 30em;
 }
 
+#paper .doi {
+  position: relative;
+  font-style: italic;
+}
+
+#paper .doi .value {
+  margin-left: -25px;
+  padding-left: 25px;
+  font-style: normal;
+}
+
 #paper .link .value {
   white-space: nowrap;
   display: inline-block;

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -239,7 +239,7 @@
     _.setDataProps(paperEl, '.enteredby.needs-owner', 'owner', paper.enteredBy);
 
     addConfirmedUpdater('#paper .link span.editing', '#paper .link button.confirm', '#paper .link button.cancel', 'textContent', identity, paper, 'link');
-    addConfirmedUpdater('#paper .doi span.editing', '#paper .doi button.confirm', '#paper .doi button.cancel', 'textContent', identity, paper, 'doi');
+    addConfirmedUpdater('#paper .doi span.editing', '#paper .doi button.confirm', '#paper .doi button.cancel', 'textContent', identity, paper, 'doi', null, 'doi:' );
 
     // workaround for chrome not focusing right
     // clicking on the placeholder 'doi' of an empty editable doi value focuses the element but doesn't react to subsequent key strokes
@@ -1177,8 +1177,9 @@
     });
   }
 
-  function addConfirmedUpdater(root, selector, confirmselector, cancelselector, property, validatorSanitizer, target, targetProp, deleteFunction) {
+  function addConfirmedUpdater(root, selector, confirmselector, cancelselector, property, validatorSanitizer, target, targetProp, deleteFunction, substringToTrim) {
     if (!(root instanceof Node)) {
+      substringToTrim = deleteFunction;
       deleteFunction = targetProp;
       targetProp = target;
       target = validatorSanitizer;
@@ -1269,6 +1270,8 @@
 
     confirmEl.onclick = function () {
       var value = editingEl[property];
+      // if we're given a substringToTrim, lets do that..
+      value = value.replace(substringToTrim, '');
       if (typeof value === 'string' && value.trim() === '') value = '';
       try {
         if (validatorSanitizer) value = validatorSanitizer(value, editingEl, property);

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -99,7 +99,7 @@
     <p class="doi linkedit edithighlight">
       <span data-focuses=".value.editing">DOI: </span>
       <a class="value notediting" href="error" data-base="https://dx.doi.org/">error</a>
-      <span class="value editing" contenteditable placeholder="doi">error</span>
+      <span class="doi">doi:</span><span class="value doi editing" contenteditable placeholder="doi">error</span>
       <button class="test editing" title="opens the link in a new window">test</button>
       <button class="confirm editing">confirm</button>
       <button class="cancel editing">cancel</button>


### PR DESCRIPTION
There is now a permenant doi: which cannot be removed but does not get
sent to the datastore.

In addition, to better handle copy-pasting into the box the string 'doi:'
is replace with ''. To facilitate this added a new parameter to
addConfirmedUpdater to allow us to reuse the ability to 'trim' a substring.