### PR TITLE
Papers: Change how adding new comments is handled

### DIFF
--- a/server/storage.js
+++ b/server/storage.js
@@ -14,7 +14,7 @@ const config = require('./config');
 
 const gcloud = require('google-cloud')(config.gcloudProject);
 
-const datastore = gcloud.datastore({ namespace: config.gcloudDatastoreNamespace });
+const datastore = gcloud.datastore({ namespace: config.gcloudDatastoreNamespace, apiEndpoint: 'http://localhost:8876'});
 
 const TITLE_RE = module.exports.TITLE_RE = '[a-zA-Z0-9.-]+';
 const TITLE_REXP = new RegExp(`^${TITLE_RE}$`);

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -101,6 +101,15 @@ body > footer > p {
   display: none;
 }
 
+/* Material icons: */
+.material-icons.md-18 {
+  font-size: 18px;
+}
+
+.material-icons {
+  cursor: pointer;
+}
+
 /* popupbox
  *
  *

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -97,6 +97,10 @@ body > footer > p {
   font-family: monospace;
 }
 
+.hidden {
+  display: none;
+}
+
 /* popupbox
  *
  *

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -809,6 +809,8 @@
       _.fillEls(el, '.ctime', _.formatDateTime(comment.ctime || Date.now()));
       _.fillEls(el, '.text', comment.text);
 
+      _.addEventListener(el, '.edit-icon', 'click', focusAnotherElementOnClick);
+
       addOnInputUpdater(el, '.text', 'textContent', identity, paper, commentsPropPath.concat(i, 'text'));
       textTargetEl.appendChild(el);
     }

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -814,18 +814,43 @@
     }
 
     // events for adding a comment
-    _.findEls(root, '.comment.new .text').forEach(function (el) {
-      el.onblur = function () {
-        var text = el.textContent;
-        el.textContent = '';
-        if (text.trim()) {
-          var comments = getDeepValue(paper, commentsPropPath, []);
-          comments.push({ text: text });
-          fillComments(templateId, root, countSelector, textSelector, paper, commentsPropPath);
-          _.setYouOrName(); // the new comment needs to be marked as "yours" so you can edit it
-          _.scheduleSave(paper);
-        }
+    var buttons = _.findEls(root, '.comment.new .buttons');
+    var newComment = _.findEls(root, '.comment.new .text');
+    newComment = newComment[0];
+
+    // show buttons on focus
+    newComment.onfocus = function () {
+      buttons[0].classList.remove('hidden');
+    }
+
+    // enable/disable the add button based on content
+    newComment.oninput = function () {
+      var text = newComment.textContent;
+      if (text.trim() != ''){
+        buttons[0].lastElementChild.disabled = false;
+      } else {
+        buttons[0].lastElementChild.disabled = true;
       }
+    }
+
+    // add
+    _.addEventListener(root, '.comment.new .add', 'click', function() {
+      var text = newComment.textContent;
+      newComment.textContent = '';
+      if (text.trim()) {
+        var comments = getDeepValue(paper, commentsPropPath, []);
+        comments.push({ text: text });
+        fillComments(templateId, root, countSelector, textSelector, paper, commentsPropPath);
+        _.setYouOrName(); // the new comment needs to be marked as "yours" so you can edit it
+        _.scheduleSave(paper);
+      }
+      buttons[0].classList.add('hidden');
+    });
+
+    // cancel
+    _.addEventListener(root, '.comment.new .cancel', 'click', function() {
+      newComment.textContent = '';
+      buttons[0].classList.add('hidden');
     });
   }
 

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -298,7 +298,7 @@
 <template id="comment-template">
   <div class="comment">
     <header>
-      #<span class="commentnumber"></span>: <a class="by" href="error">error</a> wrote on <span class="ctime date"></span>:
+      #<span class="commentnumber"></span>: <a class="by" href="error">error</a> wrote on <span class="ctime date"></span>:<span data-focuses='.comment .text' class="edit-icon material-icons md-18 only-if-yours needs-owner">edit</span>
     </header>
     <p><span class="text only-if-yours needs-owner" contenteditable placeholder="enter your comment"></span></p>
     <p><span class="text only-not-yours needs-owner"></span></p>

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -284,7 +284,13 @@
         <header>
           new comment:
         </header>
-        <p><span class="text" contenteditable placeholder="enter a new comment"></span><button class="add">add comment</button></p>
+        <p>
+          <span class="text" contenteditable placeholder="enter a new comment"></span>
+          <span class="buttons hidden">
+            <button class="cancel">cancel</button>
+            <button class="add" disabled>add comment</button>
+          </span>
+        </p>
       </div>
     </div>
   </td>


### PR DESCRIPTION
This commit changes the behaviour surrounding adding a new comment.

I have used github as inspiration.

Previously onblur of the text field would add it as a comment, and the
'add' button did nothing more but steal focus.

Now I have added a more intuitive behaviour. On focus of the text box
there is a cancel and add button displayed. These will be shown until either
a comment is added, or a user cancels. The add button is disabled if there
is not a valid comment written inside.