### PR TITLE
Papers: Move columns around hidden columns fix

### DIFF
--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -1370,7 +1370,8 @@
 
     var i = currentPaper.columnOrder.indexOf(colId);
     if (i === -1) return console.error('column ' + colId + ' not found in newly regenerated order!');
-    _.moveInArray(currentPaper.columnOrder, i, left, most);
+    var nextNonHidden = findNextNonHiddenCol(i, left);
+    _.moveInArray(currentPaper.columnOrder, i, nextNonHidden, left, most);
     moveResultsAfterCharacteristics(currentPaper);
     updatePaperView();
     _.scheduleSave(currentPaper);
@@ -1385,6 +1386,43 @@
         firstResult++;
       }
     }
+  }
+
+  function findNextNonHiddenCol(currentIndex, left) {
+    var found = false;
+    var nextColIndex = currentIndex;
+    if (left) {
+      nextColIndex -= 1;
+      while (!found) {
+        if (typeof currentPaper.columnOrder[nextColIndex] === 'undefined') {
+          // We've hit the end, return 0
+          nextColIndex = 0;
+          break;
+        }
+        if (isHiddenCol(currentPaper.columnOrder[nextColIndex])) {
+          nextColIndex -= 1;
+          continue;
+        } else {
+          break;
+        }
+      }
+    } else {
+      nextColIndex += 1;
+      while (!found) {
+        if (typeof currentPaper.columnOrder[nextColIndex] === 'undefined') {
+          // We've hit the end, return .length-1
+          nextColIndex = currentPaper.columnOrder.length-1;
+          break;
+        }
+        if (isHiddenCol(currentPaper.columnOrder[nextColIndex])) {
+          nextColIndex += 1;
+          continue;
+        } else {
+          break;
+        }
+      }
+    }
+    return nextColIndex;
   }
 
   function changeColumnType(ev) {

--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -188,14 +188,14 @@
    * Move item `i` in array `arr` to the left or right.
    * `left` indicates direction; if `most`, move to the beginning (left) or end (right) of the array.
    */
-  _.moveInArray = function moveInArray(arr, i, left, most) {
+  _.moveInArray = function moveInArray(arr, i, j, left, most) {
     var moveTo = undefined;
     if (left) {
       if (i === 0) return arr;
-      moveTo = most ? 0 : i-1;
+      moveTo = most ? 0 : j;
     } else {
       if (i === arr.length - 1) return arr;
-      moveTo = most ? arr.length - 1 : i+1;
+      moveTo = most ? arr.length - 1 : j;
     }
 
     _.moveArrayElement(arr, i, moveTo);


### PR DESCRIPTION
Now move to the left or right of the next non-Hidden column.

Will need porting to Meta-analysis when finalised.

Fixes #27