### PR TITLE
drop papers from meta-analysis, only keep paperOrder

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -434,7 +434,6 @@ function extractMetaanalysisForSending(storageMetaanalysis, email) {
     paperOrder: storageMetaanalysis.paperOrder,
     hiddenCols: storageMetaanalysis.hiddenCols,
     hiddenExperiments: storageMetaanalysis.hiddenExperiments,
-    papers: storageMetaanalysis.papers,
     // todo comments in various places?
   };
 
@@ -458,7 +457,6 @@ function extractReceivedMetaanalysis(receivedMetaanalysis) {
     paperOrder:        tools.array(receivedMetaanalysis.paperOrder, tools.string),
     hiddenCols:        tools.array(receivedMetaanalysis.hiddenCols, tools.string),
     hiddenExperiments: tools.array(receivedMetaanalysis.hiddenExperiments, tools.string),
-    papers:            tools.array(receivedMetaanalysis.papers, tools.string),
   };
 
   return retval;

--- a/server/storage.js
+++ b/server/storage.js
@@ -80,6 +80,7 @@ function checkForDisallowedChanges(current, original, columns) {
   //   do the checks we can think of for changes that wouldn't be allowed
   // for example, we can't really allow removing values because we don't allow removing comments
   // todo comment mtimes
+  // todo check that columnOrder references existing columns; that paperOrder references existing papers
   // this might end up being different for papers and for metaanalyses
 
   original = original || {};


### PR DESCRIPTION
we only need to have paperOrder in a metaanalysis, that tells us what papers we should take into account; we don't have "hidden" papers in MA