### PR TITLE
AddColumn: Include Yours/Others Computed columns (if valid)

### DIFF
--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -883,27 +883,61 @@
     var list = _.findEl('#metaanalysis table.experiments tr:first-child th.add .addcolumnbox > ul');
     list.innerHTML='';
     var user = lima.getAuthenticatedUserEmail();
-    var ordered = {yours: { result: [], characteristic: []},
-                   other: { result: [], characteristic: []},
-                   already: { result: [], characteristic: []}};
+    var ordered = {yours: { result: [], characteristic: [],
+                            computedValid: [], computedInvalid: []},
+                   other: { result: [], characteristic: [],
+                            computedValid: [], computedInvalid: []},
+                   already: { result: [], characteristic: [],
+                            computedValid: [], computedInvalid: []}
+                  };
     Object.keys(columns).forEach(function(colId) {
       var col = columns[colId];
+      var colType = col.type;
       var bucket = (col.definedBy === user || !col.definedBy) ? 'yours' : 'other';
       if (currentMetaanalysis.columnOrder.indexOf(colId) > -1) bucket = 'already';
-      ordered[bucket][col.type].push(col);
+      if (col.formula) {
+        if (metaanalysisContainsAllFormulaColumns(currentMetaanalysis.columnOrder, col.formulaColumns)) {
+          colType = 'computedValid'
+        } else {
+          colType = 'computedInvalid';
+        }
+      }
+      ordered[bucket][colType].push(col);
     })
     ordered.yours.result.sort(compareColumnsByAuthorAndTitle);
     ordered.yours.characteristic.sort(compareColumnsByAuthorAndTitle);
+    ordered.yours.computedValid.sort(compareColumnsByAuthorAndTitle);
     ordered.other.result.sort(compareColumnsByAuthorAndTitle);
     ordered.other.characteristic.sort(compareColumnsByAuthorAndTitle);
+    ordered.other.computedValid.sort(compareColumnsByAuthorAndTitle);
     ordered.already.result.sort(compareColumnsByAuthorAndTitle);
     ordered.already.characteristic.sort(compareColumnsByAuthorAndTitle);
+    ordered.already.computedValid.sort(compareColumnsByAuthorAndTitle);
     // todo add collapsing of these blocks on clicking the header
-    addColumnsBlock(list, 'your characteristic/moderator columns:', ordered.yours.characteristic);
-    addColumnsBlock(list, 'your result columns:', ordered.yours.result);
-    addColumnsBlock(list, 'characteristic/moderator columns:', ordered.other.characteristic);
-    addColumnsBlock(list, 'result columns:', ordered.other.result);
-    addColumnsBlock(list, 'columns used in the meta-analysis:', ordered.already.characteristic.concat(ordered.already.result));
+    // TODO: Sometime in the future we may wish to show computedInvalid.
+    addColumnsBlock(list,
+                    'your characteristic/moderator columns:',
+                    ordered.yours.characteristic);
+    addColumnsBlock(list,
+                    'your result columns:',
+                    ordered.yours.result);
+    addColumnsBlock(list,
+                    'your computed columns (that fit the existing data):',
+                    ordered.yours.computedValid);
+    addColumnsBlock(list,
+                    'characteristic/moderator columns:',
+                    ordered.other.characteristic);
+    addColumnsBlock(list,
+                    'result columns:',
+                    ordered.other.result);
+    addColumnsBlock(list,
+                    'computed columns (that fit the existing data):',
+                    ordered.other.computedValid);
+    addColumnsBlock(list,
+                    'columns used in the paper:',
+                    ordered.already.characteristic.concat(
+                      ordered.already.result, ordered.already.computedValid
+                    ));
     _.removeClass('#metaanalysis table.experiments tr:first-child th.add .addcolumnbox.loading', 'loading');
     _.setYouOrName();
 
@@ -1488,6 +1522,17 @@
 
     updateMetaanalysisView();
     _.scheduleSave(currentMetaanalysis);
+  }
+
+  function metaanalysisContainsAllFormulaColumns(metaanalysisColumnOrder, formulaColumns) {
+    // TODO? Formula columns might be undefined, if so do we can show this column?
+    if (!formulaColumns) return false;
+    if (!metaanalysisColumnOrder) return false;
+
+    for (var i = 0; i < formulaColumns.length; i++) {
+        if (metaanalysisColumnOrder.indexOf(formulaColumns[i]) == -1) return false;
+    }
+    return true;
   }
 
   /* DOM updates


### PR DESCRIPTION
If the paper/metaanalysis contains the required formulaColumns for
a Computed column, then show the computed column as an option to add.

New sections 'Your computed columns' and 'computed columns'.

Left 'computedInvalid' as an option so we can easily expand if we
want to show those in the future.