### PR TITLE
let's do a closed, invitation-only, beta testing stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *-google-key.json
 log
+invites.txt

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ git diff -u              # review everything
 npm install              # if package.json has changed
 forever restart server   # if server has changed
 ```
+
+## invite codes
+
+For now with `./invites.txt` to generate an invite, append a line like this:
+
+```
+random-code-12345 # 2017-02-28 generated for Cochrane workshop attendees
+```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "body-parser": "^1.15.2",
+    "cookie-parser": "^1.4.3",
     "express": "^4.14.0",
     "google-cloud": "^0.47.0",
     "morgan": "^1.8.1",

--- a/server/storage.js
+++ b/server/storage.js
@@ -952,6 +952,45 @@ module.exports.saveColumn = (recvCol, email) => {
 };
 
 
+/* closed beta
+ *
+ *
+ *    ####  #       ####   ####  ###### #####     #####  ###### #####   ##
+ *   #    # #      #    # #      #      #    #    #    # #        #    #  #
+ *   #      #      #    #  ####  #####  #    #    #####  #####    #   #    #
+ *   #      #      #    #      # #      #    #    #    # #        #   ######
+ *   #    # #      #    # #    # #      #    #    #    # #        #   #    #
+ *    ####  ######  ####   ####  ###### #####     #####  ######   #   #    #
+ *
+ *
+ */
+
+// a hash keyed on invite codes for closed beta users
+module.exports.betaCodes = {};
+
+// todo this should be in the data store
+module.exports.betaCodes['team-1'] = {};
+
+// when we touch a beta code (someone uses it in a request), store:
+//   last access (trigger a save if more than 24h after the last one)
+//   logged-in email address if available (triggers a save if a new address there)
+//   access count per email address per day for the last 7 days
+module.exports.touchBetaCode = (code, email) => void email;
+
+
+/* ready function
+ *
+ *
+ *   #####  ######   ##   #####  #   #    ###### #    # #    #  ####  ##### #  ####  #    #
+ *   #    # #       #  #  #    #  # #     #      #    # ##   # #    #   #   # #    # ##   #
+ *   #    # #####  #    # #    #   #      #####  #    # # #  # #        #   # #    # # #  #
+ *   #####  #      ###### #    #   #      #      #    # #  # # #        #   # #    # #  # #
+ *   #   #  #      #    # #    #   #      #      #    # #   ## #    #   #   # #    # #   ##
+ *   #    # ###### #    # #####    #      #       ####  #    #  ####    #   #  ####  #    #
+ *
+ *
+ */
+
 module.exports.ready =
   metaanalysisCache
   .then(() => paperCache)

--- a/server/storage.js
+++ b/server/storage.js
@@ -13,6 +13,7 @@ const config = require('./config');
 const tools = require('./tools');
 
 const gcloud = require('google-cloud')(config.gcloudProject);
+const fs = require('fs');
 
 const datastore = gcloud.datastore({ namespace: config.gcloudDatastoreNamespace });
 
@@ -968,8 +969,28 @@ module.exports.saveColumn = (recvCol, email) => {
 // a hash keyed on invite codes for closed beta users
 module.exports.betaCodes = {};
 
-// todo this should be in the data store
-module.exports.betaCodes['team-1'] = {};
+// load the invitation codes from a file for now
+// every line has an invite code and after # possibly a comment
+// to generate an invite, there are instructions in the README
+// todo load the codes from the data store and have a management interface, update the README
+(function () {
+  let invites;
+  try {
+    invites = fs.readFileSync('./invites.txt', 'utf8');
+  } catch (e) {
+    // let it crash
+    throw new Error('BETA: need the file ./invites.txt to allow anybody in the server');
+  }
+  const lines = invites.split(/\n/);
+  lines.forEach((line) => {
+    const code = line.split('#')[0].trim();
+    if (code) module.exports.betaCodes[code] = {};
+  });
+  if (Object.keys(module.exports.betaCodes).length === 0) {
+    throw new Error('BETA: need invite codes in ./invites.txt to allow anybody in the server');
+  }
+  console.log(`BETA: got ${Object.keys(module.exports.betaCodes).length} invites`);
+}());
 
 // when we touch a beta code (someone uses it in a request), store:
 //   last access (trigger a save if more than 24h after the last one)

--- a/webpages/coming-soon.html
+++ b/webpages/coming-soon.html
@@ -32,7 +32,7 @@
 
 <!-- sign-up button -->
 <p>
-  To sign up to our mailing list, please email <a href="mailto:jacek.kopecky@port.ac.uk">jacek.kopecky@port.ac.uk</a>.
+  To sign up for LiMA news and announcements, please email <a href="mailto:jacek.kopecky@port.ac.uk">jacek.kopecky@port.ac.uk</a>.
 </p>
 
 <form id="inviteform">
@@ -41,7 +41,7 @@
 
     <span id=cookieuse>
       Please note that we use cookies to store the invite code.
-      By using LiMA with an invite, you express consent with our use of cookies.
+      By using LiMA with an invite, you are agreeing to our use of cookies.
     </span>
   </p>
 

--- a/webpages/coming-soon.html
+++ b/webpages/coming-soon.html
@@ -1,6 +1,24 @@
 <!doctype html>
 <title>LiMA – Living Meta-Analysis</title>
 <link rel="stylesheet" href="/css/main.css">
+<style>
+  form {
+    display: inline;
+  }
+
+  #cookieuse {
+    display: block;
+    margin-top: 1em;
+    font-style: italic;
+    padding: .5em 1em;
+    max-width: 30em;
+    background-color: #eef;
+    border: 1px solid #88f;
+    border-radius: .5em;
+  }
+
+  #invitecode:not(:valid) ~ #cookieuse { display: none; }
+</style>
 
 <header>
   <h1>LiMA (Living Meta-Analysis)</h1>
@@ -8,7 +26,7 @@
 </header>
 
 <p>
-  LiMA is now in testing, please come back in April 2017. Thank you for your interest.
+  LiMA is currently in invitation-only beta testing. Thank you for your interest.
 </p>
 
 
@@ -16,6 +34,18 @@
 <p>
   To sign up to our mailing list, please email <a href="mailto:jacek.kopecky@port.ac.uk">jacek.kopecky@port.ac.uk</a>.
 </p>
+
+<form id="inviteform">
+  <p>
+    If you have an invite, please enter the code here: <input id="invitecode" type=text size=20 required autofocus><input type="submit" value="Proceed">
+
+    <span id=cookieuse>
+      Please note that we use cookies to store the invite code.
+      By using LiMA with an invite, you express consent with our use of cookies.
+    </span>
+  </p>
+
+</form>
 
 
 
@@ -25,5 +55,18 @@
 </footer>
 
 
-<script src="/js/tools.js"></script>
-<script src="/js/version.js"></script>
+<script>
+  // reset the cookie because the server did not accept it
+  if (window.location.pathname == '/') {
+    document.cookie = "lima-beta-code=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  }
+
+  // use the invite code as a cookie for server access
+  window.inviteform.onsubmit = function(e) {
+    e.preventDefault();
+    if (window.invitecode.value.trim()) {
+      document.cookie = "lima-beta-code=" + encodeURIComponent(window.invitecode.value.trim()) + "; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+      window.location.href="/?closedbeta";
+    }
+  }
+</script>

--- a/webpages/index.html
+++ b/webpages/index.html
@@ -21,7 +21,9 @@
 </header>
 
 <p class="alert">
-  LiMA is now in testing, please come back in April 2017. Thank you for your interest.
+  LiMA is now in testing, thank you for taking part. Please send your thoughts and feedback to
+  <a href="mailto:jacek.kopecky@port.ac.uk">jacek.kopecky@port.ac.uk</a>, or
+  <a href="https://github.com/jacekkopecky/living-meta-analysis/issues">report and discuss issues on GitHub</a>.
 </p>
 
 

--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -323,7 +323,7 @@
 
   _.notFound = function notFound() {
     document.body.innerHTML = '';
-    fetch('/404')
+    fetch('/404', { credentials: 'same-origin' })
     .then(_.fetchText)
     .catch(function (err) {
       console.error('error getting 404');
@@ -339,7 +339,7 @@
 
   _.apiFail = function apiFail() {
     document.body.innerHTML = '';
-    fetch('/apifail')
+    fetch('/apifail', { credentials: 'same-origin' })
     .then(_.fetchText)
     .catch(function (err) {
       console.error('error getting apifail page');

--- a/webpages/js/version.js
+++ b/webpages/js/version.js
@@ -9,7 +9,7 @@
 
   footer.innerHTML += '<p class="limaversion">version <span class="value">&hellip;</span> (<a href="/version/log">full changelog</a>)</p>';
 
-  fetch('/version')
+  fetch('/version', { credentials: 'same-origin' })
   .then(_.fetchText)
   .then(function (text) { _.fillEls('.limaversion .value', text)})
   .catch(function (err) {


### PR DESCRIPTION
This code uses cookies to store an invitation code.

This PR doesn't have any management of invitation codes yet; a first trivial step is to load them from a file, then we can add the proper functionality of loading them from the data store and keeping statistics.

## Tasks, in order of priority 

- [ ] load invite codes from a file on start

- [ ] load invite codes from the data store

- [ ] make a page for adding invites:
  - generate code (or several codes)
  - store expected email address (optional)
  - store a description (optional, e.g. "generated 100 invites for use by Cochrane workshop participants")
  - needs "how many codes to generate"

- [ ] keep statistics of invite code accesses
  - last access (triggers a save if more than 24h after the last one)
  - logged-in email address if available (triggers a save if a new address there)
  - access count per email address per day for the last 7 days

- [ ] make a page for reviewing invites for closed beta participants
  - first: active invites, ordered initally by MRU
    - shows each code
    - when it was generated
    - stored expected email address
    - stored description
    - last access time
    - all email addresses, in MRU order, with per-day access counts
    - button to revoke code - immediately revokes, shows an input to add revocation reason (optional)
  - next: revoked invites, ordered by revocation time stamp
    - all as the above, button to generate new code, pre-fills page for adding invites
