### PR TITLE
experiment table: don't allow values to break to multiple lines

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -1531,6 +1531,11 @@ body:not(.page-about-you).signed-on #metaanalysis > header .edityourcopy {
   padding-right: 23em; /* 15em for width of popupbox and 8em for width of overhanging column labels and new column box */
 }
 
+#paper table.experiments td span.value,
+#metaanalysis table.experiments td span.value {
+  white-space: nowrap;
+}
+
 #paper.no-data table.experiments,
 #metaanalysis.no-data table.experiments {
   padding-right: 17em; /* 15em for width of popupbox and 2em for extra gap */


### PR DESCRIPTION
When something generates -Infinity, this would get broken after the ‘-‘
because the table cell wants to be narrow.

The HTML template `experiment-datum-template` declares the value to be `oneline` anyway.