### PR TITLE
server: don't display commit messages in version string

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -175,7 +175,7 @@ function oneLineVersion(req, res) {
   res.send(oneLineVersionString);
 }
 
-exec('git log -1 --pretty=format:"%ai \'%s\'"',
+exec('git log -1 --date=short --pretty=format:"%ad"',
   (error, stdout, stderr) => {
     if (error) oneLineVersionString = 'error getting version: ' + error + '\n' + stderr;
     else oneLineVersionString = stdout;


### PR DESCRIPTION
Commit messages are not meant to make sense to users, therefore I don't know what I was thinking when I first put them in the version string.

This PR suggests we only use the date of the last commit as the version.