### PR TITLE
Metaanalysis: Exclude experiments from aggregate calculations

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -419,6 +419,7 @@ function extractMetaanalysisForSending(storageMetaanalysis, includePapers, email
     paperOrder: storageMetaanalysis.paperOrder,
     hiddenCols: storageMetaanalysis.hiddenCols,
     hiddenExperiments: storageMetaanalysis.hiddenExperiments,
+    excludedExperiments: storageMetaanalysis.excludedExperiments,
     aggregates: storageMetaanalysis.aggregates,
     // todo comments in various places?
   };
@@ -436,19 +437,20 @@ function extractMetaanalysisForSending(storageMetaanalysis, includePapers, email
 function extractReceivedMetaanalysis(receivedMetaanalysis) {
   // expecting receivedMetaanalysis to come from JSON.parse()
   const retval = {
-    id:                tools.string(receivedMetaanalysis.id),        // identifies the MA to be changed
-    title:             tools.string(receivedMetaanalysis.title),
-    CHECKenteredBy:    tools.string(receivedMetaanalysis.enteredBy), // can't be changed but should be checked
-    CHECKctime:        tools.number(receivedMetaanalysis.ctime),     // can't be changed but should be checked
+    id:                  tools.string(receivedMetaanalysis.id),        // identifies the MA to be changed
+    title:               tools.string(receivedMetaanalysis.title),
+    CHECKenteredBy:      tools.string(receivedMetaanalysis.enteredBy), // can't be changed but should be checked
+    CHECKctime:          tools.number(receivedMetaanalysis.ctime),     // can't be changed but should be checked
     // mtime: tools.number(receivedMetaanalysis.mtime),              // will be updated
-    published:         tools.string(receivedMetaanalysis.published),
-    description:       tools.string(receivedMetaanalysis.description),
-    tags:              tools.array(receivedMetaanalysis.tags, tools.string),
-    columns:           tools.array(receivedMetaanalysis.columns, extractReceivedColumnEntry),
-    paperOrder:        tools.array(receivedMetaanalysis.paperOrder, tools.string),
-    hiddenCols:        tools.array(receivedMetaanalysis.hiddenCols, tools.string),
-    hiddenExperiments: tools.array(receivedMetaanalysis.hiddenExperiments, tools.string),
-    aggregates:        tools.array(receivedMetaanalysis.aggregates, extractReceivedAggregate),
+    published:           tools.string(receivedMetaanalysis.published),
+    description:         tools.string(receivedMetaanalysis.description),
+    tags:                tools.array(receivedMetaanalysis.tags, tools.string),
+    columns:             tools.array(receivedMetaanalysis.columns, extractReceivedColumnEntry),
+    paperOrder:          tools.array(receivedMetaanalysis.paperOrder, tools.string),
+    hiddenCols:          tools.array(receivedMetaanalysis.hiddenCols, tools.string),
+    hiddenExperiments:   tools.array(receivedMetaanalysis.hiddenExperiments, tools.string),
+    excludedExperiments: tools.array(receivedMetaanalysis.excludedExperiments, tools.string),
+    aggregates:          tools.array(receivedMetaanalysis.aggregates, extractReceivedAggregate),
   };
 
   return retval;

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -1061,6 +1061,26 @@ body:not(.page-about-you).signed-on #paper > header .edityourcopy {
   display: inline-block;
 }
 
+#metaanalysis table.experiments th.papertitle > div > .exclude,
+#metaanalysis table.experiments th.experimenttitle > div > .exclude {
+  display:none;
+}
+
+#metaanalysis table.experiments th.papertitle:hover > div > .exclude,
+#metaanalysis table.experiments th.experimenttitle:hover > div > .exclude{
+  display: inline-block;
+  position: absolute;
+  right: 0;
+  margin-right: .3em;
+}
+
+#metaanalysis table.experiments tr.papexcluded th > *:not(.popupbox),
+#metaanalysis table.experiments tr.excluded th:not(.papertitle) > *:not(.popupbox),
+#metaanalysis table.experiments tr.excluded td > *:not(.popupbox){
+  color: grey;
+  font-style: italic;
+}
+
 #metaanalysis .unhide {
   display: none;
 }

--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -230,9 +230,6 @@
     if (document.activeElement === editEl) ev.preventDefault();
   }
 
-
-
-
   /* array manipulation
    *
    *

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -266,7 +266,7 @@
   <tr class="row">
     <th class="popupboxtrigger popupboxhighlight papertitle">
       <!-- todo click on title or exptitle should focus the contenteditable exptitle -->
-      <span class="paptitle"></span>
+      <div><span class="paptitle"></span><input type="checkbox" class="exclude" checked></div>
       <div class="paperinfo popupbox" data-boxtype='paperinfo'>
         <div class="pin"></div>
         <header>
@@ -326,7 +326,7 @@
     </th>
     <th class="popupboxtrigger popupboxhighlight experimenttitle">
       <!-- todo click on title or exptitle should focus the contenteditable exptitle -->
-      <span class="exptitle"></span>
+      <div><span class="exptitle"></span><input type="checkbox" class="exclude" checked></div>
       <div class="experimentinfo popupbox" data-boxtype='experimentinfo'>
         <div class="pin"></div>
         <header>


### PR DESCRIPTION
Checkbox on every experimenttitle, which can be unchecked to add the
experiment into ma.excludedExperiments (in the form <paper.id>,<expIndex>)

Checkbox on every papertitle, which can be unchecked to add all
of that papers experiments into ma.excludedExperiments.

On page load css styling is added to row(s) which was excluded, and
aggregates ignore values if they are from an excluded experiment.