### PR TITLE
Profile: remove MA "date" field

### DIFF
--- a/webpages/profile/profile.html
+++ b/webpages/profile/profile.html
@@ -52,7 +52,7 @@
     </div>
   </header>
   <template id="metaanalysis-list-item-template">
-    <li><a href="" class="name mainlink">error</a> <span class="date">error</span> <span class="description">error</span>
+    <li><a href="" class="name mainlink">error</a><span class="description">error</span>
       <ul class="tags">
       </ul>
     </li>


### PR DESCRIPTION
Previously just showed "error", for cochrane better to show
nothing than error.