### PR TITLE
server: log invite codes

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -12,7 +12,7 @@ module.exports = {
   // where to store Web access logs; relative to project root
   logDirectory: './log',
   // morgan format for access log lines, default is 'combined'
-  logFormat: ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :response-time[0] ms',   // eslint-disable-line
+  logFormat: ':remote-addr :invite :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :response-time[0] ms',   // eslint-disable-line
 
   // this is a delay for demonstration purposes so the server seems slow
   demoApiDelay: 0,

--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,7 @@ app.set('case sensitive routing', true);
 app.set('strict routing', true);
 
 app.use(googleOpenID(process.env.GOOGLE_CLIENT_ID));
+app.use(cookieParser());
 
 /* logging
  *
@@ -47,6 +48,11 @@ app.use(googleOpenID(process.env.GOOGLE_CLIENT_ID));
 let loggingMiddleware;
 
 if (config.logDirectory) {
+  morgan.token('invite', (req) => {
+    let retval = req.cookies['lima-beta-code'] || '';
+    if (!storage.betaCodes.hasOwnProperty(req.cookies['lima-beta-code'])) retval = '-' + retval;
+    return retval;
+  });
   // ensure log directory exists
   if (!fs.existsSync(config.logDirectory)) fs.mkdirSync(config.logDirectory);
 
@@ -86,7 +92,7 @@ if (config.logDirectory) {
 // regex for quickly checking for selected paths to be allowed: /css, /js, /img, /api
 const closedBetaAllowedURLs = /^\/(css|js|img|api)\//;
 
-app.use('/', cookieParser(), (req, res, next) => {
+app.use('/', (req, res, next) => {
   if (req.url.match(closedBetaAllowedURLs)) {
     next();
   } else if (storage.betaCodes.hasOwnProperty(req.cookies['lima-beta-code'])) {


### PR DESCRIPTION
this PR puts the invite code from the cookie, prefixed with '-' if it's an invalid code, into access log. This way we can monitor what invited participants work with.