### PR TITLE
storage: add scripts for dumping and restoring data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ echo $code '#' `date +"%Y-%m-%d %H:%M"` $1
 
 ## database dumps and restores
 
+We have server-side datastore dump and restore scripts. They communicate directly with the datastore as configured in `config.js`; the LiMA server should be down while the restore script is running.
+
 To dump the currently configured data store:
 
 `npm run db-dump > dumpfile`
 
-To restore from a dumpfile:
+To restore from a dumpfile, first stop LiMA server, then run the following:
 
 `npm run db-add < dumpfile`
+
+After restoring data, start LiMA server again and it should see the new data.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,13 @@ done
 
 echo $code '#' `date +"%Y-%m-%d %H:%M"` $1
 ```
+
+## database dumps and restores
+
+To dump the currently configured data store:
+
+`npm run db-dump > dumpfile`
+
+To restore from a dumpfile:
+
+`npm run db-add < dumpfile`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server",
     "nodemon": "node_modules/.bin/nodemon -i webpages/ server",
-    "forever": "node_modules/.bin/nodemon -i webpages/ server"
+    "forever": "node_modules/.bin/nodemon -i webpages/ server",
+    "db-dump": "node server/storage-dump",
+    "db-add": "node server/storage-add"
   },
   "repository": {
     "type": "git",

--- a/server/storage-add.js
+++ b/server/storage-add.js
@@ -1,0 +1,93 @@
+'use strict';
+
+// normal logging goes to stderr
+console.log = console.error;
+
+// read JSON from stdin
+const inputData = new Promise((resolve, reject) => {
+  const stdin = process.stdin;
+  const inputChunks = [];
+
+  stdin.resume();
+  stdin.setEncoding('utf8');
+
+  stdin.on('data', (chunk) => { inputChunks.push(chunk); });
+
+  stdin.on('end', () => {
+    try {
+      resolve(JSON.parse(inputChunks.join('')));
+    } catch (e) {
+      console.error(e && e.stack || e);
+      reject(e);
+    }
+  });
+});
+
+function log(e) {
+  console.error(e && e.stack || e);
+}
+
+let storage;
+let data;
+
+inputData
+.catch(() => process.exit(1))
+.then((d) => {
+  data = d;
+  storage = require('./storage'); // eslint-disable-line global-require
+  return storage.ready;
+})
+.then(() => {
+  let promises = [];
+
+  if ('users' in data) {
+    for (const userID of Object.keys(data.users)) {
+      promises.push(storage.addUser(userID, data.users[userID]));
+    }
+  }
+
+  promises = promises.map((promise) => promise.catch(log));
+  console.log(`ready to process ${promises.length} users`);
+  return Promise.all(promises);
+})
+.then(() => {
+  let promises = [];
+
+  if ('columns' in data) {
+    for (const colId of Object.keys(data.columns)) {
+      promises.push(storage.saveColumn(data.columns[colId], null, { restoring: true }));
+    }
+  }
+
+  promises = promises.map((promise) => promise.catch(log));
+  console.log(`ready to process ${promises.length} columns`);
+  return Promise.all(promises);
+})
+.then(() => {
+  let promises = [];
+
+  if ('papers' in data) {
+    for (const paper of data.papers) {
+      promises.push(storage.savePaper(paper, null, null, { restoring: true }));
+    }
+  }
+
+  promises = promises.map((promise) => promise.catch(log));
+  console.log(`ready to process ${promises.length} papers`);
+  return Promise.all(promises);
+})
+.then(() => {
+  let promises = [];
+
+  if ('metaanalyses' in data) {
+    for (const metaanalysis of data.metaanalyses) {
+      promises.push(storage.saveMetaanalysis(metaanalysis, null, null, { restoring: true }));
+    }
+  }
+
+  promises = promises.map((promise) => promise.catch(log));
+  console.log(`ready to process ${promises.length} metaanalyses`);
+  return Promise.all(promises);
+})
+.then(() => console.log('all done'))
+.catch((e) => console.error('error saving: ', e && e.stack || e));

--- a/server/storage-dump.js
+++ b/server/storage-dump.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// normal logging goes to stderr
+const log = console.log;
+console.log = console.error;
+
+const storage = require('./storage');
+
+const data = {};
+
+storage.ready
+.then(storage.listUsers)
+.then((d) => { data.users = d; })
+.then(storage.listPapers)
+.then((d) => { data.papers = d; })
+.then(storage.listMetaanalyses)
+.then((d) => { data.metaanalyses = d; })
+.then(storage.listColumns)
+.then((d) => { data.columns = d; })
+.then(() => {
+  console.error('storage-dump done');
+  log(JSON.stringify(data, null, 2));
+});

--- a/server/tools.js
+++ b/server/tools.js
@@ -97,6 +97,7 @@ module.exports.deleteCHECKvalues = function deleteCHECKvalues(obj) {
   }
 };
 
+// resolves when the given promise is done, regardless of whether resolved or rejected
 module.exports.waitForPromise = function waitForPromise(p) {
   return new Promise((resolve /* ignoring the reject function */) => {
     Promise.resolve(p).then(() => resolve(), () => resolve());


### PR DESCRIPTION
adds scripts for dumping and restoring data.
To dump the currently configured data store:

`npm run db-dump > dumpfile`

To restore from a dumpfile:

`npm run db-add < dumpfile`