### PR TITLE
Fixed react to click above "Living Meta-Analysis" logo

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -81,16 +81,22 @@ body > header h1 {
   font-family: "Gruppo";
 }
 
-body > header .logo a:link,
-body > header .logo a:visited,
-body > header .logo a:hover,
-body > header .logo a:active {
+body > header #logo-box h1,
+body > header #logo-box h2 {
+  display:inline-block;
+}
+
+body > header a#logo-box:link,
+body > header a#logo-box:visited,
+body > header a#logo-box:hover,
+body > header a#logo-box:active {
   text-decoration: none;
   color: black;
 }
 
-body > header .logo a:hover { color: #00f; }
-body > header .logo a:active { color: #f00; }
+body > header a#logo-box:hover { color: #00f; }
+body > header a#logo-box:active { color: #f00; }
+
 
 
 

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -11,8 +11,10 @@
 <body class="loading">
 
 <header>
-  <h1 class="logo"><a href="/">LiMA</a></h1> <h2 class="logo"><a href="/">Living Meta-Analysis</a></h2>
-
+  <a href="/" id="logo-box">
+    <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
+  </a>
+  
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -11,8 +11,10 @@
 <body class="loading">
 
 <header>
-  <h1 class="logo"><a href="/">LiMA</a></h1> <h2 class="logo"><a href="/">Living Meta-Analysis</a></h2>
-
+  <a href="/" id="logo-box">
+    <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
+  </a>
+  
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">

--- a/webpages/profile/profile.html
+++ b/webpages/profile/profile.html
@@ -6,8 +6,10 @@
 <link rel="stylesheet" href="/css/main.css">
 
 <header>
-  <h1 class="logo"><a href="/">LiMA</a></h1> <h2 class="logo"><a href="/">Living Meta-Analysis</a></h2>
-
+  <a href="/" id="logo-box">
+    <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
+  </a>
+  
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" class="userphoto">

--- a/webpages/signin.html
+++ b/webpages/signin.html
@@ -1,4 +1,4 @@
-om<!doctype html>
+<!doctype html>
 <title>Sign In... | Living Meta-Analysis</title>
 <script src="/lib/promise.js"></script>
 <script src="/lib/fetch.js"></script>

--- a/webpages/signin.html
+++ b/webpages/signin.html
@@ -1,4 +1,4 @@
-<!doctype html>
+om<!doctype html>
 <title>Sign In... | Living Meta-Analysis</title>
 <script src="/lib/promise.js"></script>
 <script src="/lib/fetch.js"></script>
@@ -6,7 +6,9 @@
 <link rel="stylesheet" href="/css/main.css">
 
 <header>
-  <h1 class="logo"><a href="/">LiMA</a></h1> <h2 class="logo"><a href="/">Living Meta-Analysis</a></h2>
+  <a href="/" id="logo-box">
+    <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
+  </a>
 </header>
 
 <h1>Please sign in:</h1>


### PR DESCRIPTION
Issue 65 fixed. The logo now react as a rectangle link, it's possible to click above "Living Meta-Analysis" and return to home page.