### PR TITLE
Add automatically a comment when a user change a value

### DIFF
--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -2415,6 +2415,51 @@
       }
     });
 
+    // Add a comment when a value is changed
+    var spanValue = null;
+
+    _.addEventListener(root, 'span.value.editing.oneline', 'focusin', function() {
+      var focusSpan = _.findEl(root, 'span.value.editing.oneline');
+      spanValue = focusSpan.innerHTML;
+    });
+
+    _.addEventListener(root, 'span.value.editing.oneline', 'focusout', function() {
+      var unfocusSpan = _.findEl(root, 'span.value.editing.oneline');
+
+      if (spanValue != unfocusSpan.innerHTML) {
+        // Get the current paper, and then calculate the selected line
+        var paperRow = _.findPrecedingEl(root, 'tr');
+        var currentPaper = currentMetaanalysis.papers[paperRow.getAttribute('data-paper-index')];
+        var line = 0;
+
+        while (paperRow.getAttribute('class') != 'row paperstart') {
+          paperRow = paperRow.previousSibling;
+          line++;
+        }
+
+        // Get the column id, and then compare it with every other column ids to get the previous user name
+        var originalUser = null;
+        var currentUser = lima.getAuthenticatedUserEmail();
+        var columnId = _.findEl(root, '.datum.popupbox').getAttribute('data-boxid').split(',')[2];
+        var columnsInfos = Object.entries(currentPaper.experiments[line].data);
+
+        for (var i=0; i<columnsInfos.length; i++) {
+          if (columnsInfos[i][0] === columnId) {
+            originalUser = columnsInfos[i][1].enteredBy;
+            break;
+          }
+        }
+
+        // Add an update comment
+        var updateComment = "Previous value was \"" + spanValue + "\" (by " + originalUser + "), changed by " + currentUser + ".";
+        var comments = getDeepValue(metaanalyses, commentsPropPath, []);
+        comments.push({ text: updateComment });
+        fillComments(templateId, root, countSelector, textSelector, metaanalyses, commentsPropPath);
+        _.setYouOrName();
+        _.scheduleSave(metaanalyses);
+      }
+    });
+
     // cancel
     _.addEventListener(root, '.comment.new .buttons .cancel', 'click', function() {
       newComment.textContent = '';

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -2426,7 +2426,7 @@
     _.addEventListener(root, 'span.value.editing.oneline', 'focusout', function() {
       var unfocusSpan = _.findEl(root, 'span.value.editing.oneline');
 
-      if (spanValue != unfocusSpan.innerHTML) {
+      if (spanValue != unfocusSpan.innerHTML && spanValue != "") {
         // Get the current paper, and then calculate the selected line
         var paperRow = _.findPrecedingEl(root, 'tr');
         var currentPaper = currentMetaanalysis.papers[paperRow.getAttribute('data-paper-index')];

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -1324,7 +1324,7 @@
     _.addEventListener(root, 'span.value.editing.oneline', 'focusout', function() {
       var unfocusSpan = _.findEl(root, 'span.value.editing.oneline');
 
-      if (spanValue != unfocusSpan.innerHTML) {
+      if (spanValue != unfocusSpan.innerHTML && spanValue != "") {
         // Calculate the selected line position
         var experimentRow = unfocusSpan.parentNode.parentNode;
         var line = 0;

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -1313,6 +1313,53 @@
       }
     });
 
+    // Add a comment when a value is changed
+    var spanValue = null;
+
+    _.addEventListener(root, 'span.value.editing.oneline', 'focusin', function() {
+      var focusSpan = _.findEl(root, 'span.value.editing.oneline');
+      spanValue = focusSpan.innerHTML;
+    });
+
+    _.addEventListener(root, 'span.value.editing.oneline', 'focusout', function() {
+      var unfocusSpan = _.findEl(root, 'span.value.editing.oneline');
+
+      if (spanValue != unfocusSpan.innerHTML) {
+        // Calculate the selected line position
+        var experimentRow = unfocusSpan.parentNode.parentNode;
+        var line = 0;
+
+        while (experimentRow.className != null) {
+          experimentRow = experimentRow.previousSibling;
+          line++;
+        }
+
+        // The first tr is an empty line, so we need to remove it
+        line--;
+
+        // Get the column id, and then compare it with every other column ids to get the previous user name
+        var originalUser = null;
+        var currentUser = lima.getAuthenticatedUserEmail();
+        var columnId = _.findEl(root, '.datum.popupbox').getAttribute('data-boxid').split(',')[1];
+        var columnsInfos = Object.entries(currentPaper.experiments[line].data);
+
+        for (var i=0; i<columnsInfos.length; i++) {
+          if (columnsInfos[i][0] === columnId) {
+            originalUser = columnsInfos[i][1].enteredBy;
+            break;
+          }
+        }
+
+        // Add an update comment
+        var updateComment = "Previous value was \"" + spanValue + "\" (by " + originalUser + "), changed by " + currentUser + ".";
+        var comments = getDeepValue(paper, commentsPropPath, []);
+        comments.push({ text: updateComment });
+        fillComments(templateId, root, countSelector, textSelector, paper, commentsPropPath);
+        _.setYouOrName();
+        _.scheduleSave(paper);
+      }
+    });
+
     // cancel
     _.addEventListener(root, '.comment.new .buttons .cancel', 'click', function() {
       newComment.textContent = '';


### PR DESCRIPTION
When a user was changing a value, it was not possible to know who did it and who inserted the original value. It now add automatically a comment when someone enter a new value.

Comment format : Previous value was "previousValue" (by previousUser), changed by currentUser