### PR TITLE
MA/Paper: Display a warning when changing datum values

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -2263,6 +2263,28 @@ body.editing #metaanalysis table.experiments .fullcolinfo .coltype.yours.charact
   font-weight: normal;
 }
 
+#paper table.experiments .datum.popupbox p.changewarning,
+#metaanalysis table.experiments .datum.popupbox p.changewarning {
+  font-style: italic;
+  font-weight: bold;
+  font-size: 80%;
+}
+
+#paper table.experiments .datum.popupbox p.animated,
+#metaanalysis table.experiments .datum.popupbox p.animated {
+  animation-duration: 700ms;
+  animation-name: pulse-red;
+  animation-direction: alternate;
+  animation-iteration-count: 2;
+  animation-timing-function: ease-in-out;
+  animation-delay: 50ms;
+}
+
+@keyframes pulse-red {
+    0%   {color: black;}
+    100%  {color: rgba(169,0,0,1);}
+}
+
 #paper table.experiments .datum.popupbox .computed .computedfrom,
 #paper table.experiments .datum.popupbox .computed .formula,
 #metaanalysis table.experiments .datum.popupbox .computed .computedfrom,

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -2263,6 +2263,11 @@ body.editing #metaanalysis table.experiments .fullcolinfo .coltype.yours.charact
   font-weight: normal;
 }
 
+#paper table.experiments .datum.popupboxtrigger.empty .datum.popupbox p.changewarning,
+#metaanalysis table.experiments .datum.popupboxtrigger.empty .datum.popupbox p.changewarning {
+  display:none;
+}
+
 #paper table.experiments .datum.popupbox p.changewarning,
 #metaanalysis table.experiments .datum.popupbox p.changewarning {
   font-style: italic;
@@ -2270,8 +2275,8 @@ body.editing #metaanalysis table.experiments .fullcolinfo .coltype.yours.charact
   font-size: 80%;
 }
 
-#paper table.experiments .datum.popupbox p.animated,
-#metaanalysis table.experiments .datum.popupbox p.animated {
+#paper table.experiments td span[contenteditable]:focus + .datum.popupbox p.changewarning,
+#metaanalysis table.experiments td span[contenteditable]:focus + .datum.popupbox p.changewarning {
   animation-duration: 700ms;
   animation-name: pulse-red;
   animation-direction: alternate;

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -1420,7 +1420,6 @@
               td.classList.add('empty');
             } else {
               _.fillEls(td, '.value', val.value);
-              _.fillEls(td, '.changewarning', "When updating an existing value, consider leaving a comment justifying the change.")
             }
 
             addOnInputUpdater(td, '.value', 'textContent', trimmingSanitizer, paper, ['experiments', expIndex, 'data', col, 'value'], recalculateComputedData);
@@ -1429,16 +1428,6 @@
             _.fillEls (td, '.valenteredby', val && val.enteredBy || user);
             _.setProps(td, '.valenteredby', 'href', '/' + (val && val.enteredBy || user) + '/');
             _.fillEls (td, '.valctime', _.formatDateTime(val && val.ctime || Date.now()));
-
-            // Set up a listener to onfocus trigger the animation on the warning element
-            // only if the datum has a saved value.
-            _.addEventListener(td, '.value', 'focus', function(ev){
-              var parentEl = ev.target.parentElement;
-              if (!parentEl.classList.contains('empty')) { // we have a saved value
-                var changeWarningEl = _.findEl(parentEl, '.changewarning');
-                changeWarningEl.classList.add('animated');
-              }
-            })
 
             setupPopupBoxPinning(td, '.datum.popupbox', papIndex + ',' + expIndex + ',' + col);
 

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -1416,10 +1416,11 @@
               val = experiment.data[col];
             }
 
-            if (!val || val.value == null) {
+            if (!val || val.value == null || val.value.trim() == '') {
               td.classList.add('empty');
             } else {
               _.fillEls(td, '.value', val.value);
+              _.fillEls(td, '.changewarning', "When updating an existing value, consider leaving a comment justifying the change.")
             }
 
             addOnInputUpdater(td, '.value', 'textContent', trimmingSanitizer, paper, ['experiments', expIndex, 'data', col, 'value'], recalculateComputedData);
@@ -1428,6 +1429,16 @@
             _.fillEls (td, '.valenteredby', val && val.enteredBy || user);
             _.setProps(td, '.valenteredby', 'href', '/' + (val && val.enteredBy || user) + '/');
             _.fillEls (td, '.valctime', _.formatDateTime(val && val.ctime || Date.now()));
+
+            // Set up a listener to onfocus trigger the animation on the warning element
+            // only if the datum has a saved value.
+            _.addEventListener(td, '.value', 'focus', function(ev){
+              var parentEl = ev.target.parentElement;
+              if (!parentEl.classList.contains('empty')) { // we have a saved value
+                var changeWarningEl = _.findEl(parentEl, '.changewarning');
+                changeWarningEl.classList.add('animated');
+              }
+            })
 
             setupPopupBoxPinning(td, '.datum.popupbox', papIndex + ',' + expIndex + ',' + col);
 

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -602,7 +602,6 @@
             td.classList.add('empty');
           } else {
             _.fillEls(td, '.value', val.value);
-            _.fillEls(td, '.changewarning', "When updating an existing value, consider leaving a comment justifying the change.")
           }
 
           addOnInputUpdater(td, '.value', 'textContent', trimmingSanitizer, paper, ['experiments', expIndex, 'data', col, 'value'], recalculateComputedData);
@@ -613,16 +612,6 @@
           _.fillEls (td, '.valctime', _.formatDateTime(val && val.ctime || Date.now()));
 
           setupPopupBoxPinning(td, '.datum.popupbox', expIndex +',' + col);
-
-          // Set up a listener to onfocus trigger the animation on the warning element
-          // only if the datum has a saved value.
-          _.addEventListener(td, '.value', 'focus', function(ev){
-            var parentEl = ev.target.parentElement;
-            if (!parentEl.classList.contains('empty')) { // we have a saved value
-              var changeWarningEl = _.findEl(parentEl, '.changewarning');
-              changeWarningEl.classList.add('animated');
-            }
-          })
 
           // populate comments
           fillComments('comment-template', td, '.commentcount', '.datum.popupbox main', paper, ['experiments', expIndex, 'data', col, 'comments']);

--- a/webpages/js/papers.js
+++ b/webpages/js/papers.js
@@ -598,10 +598,11 @@
             val = experiment.data[col];
           }
 
-          if (!val || val.value == null) {
+          if (!val || val.value == null || val.value.trim() == '') {
             td.classList.add('empty');
           } else {
             _.fillEls(td, '.value', val.value);
+            _.fillEls(td, '.changewarning', "When updating an existing value, consider leaving a comment justifying the change.")
           }
 
           addOnInputUpdater(td, '.value', 'textContent', trimmingSanitizer, paper, ['experiments', expIndex, 'data', col, 'value'], recalculateComputedData);
@@ -612,6 +613,16 @@
           _.fillEls (td, '.valctime', _.formatDateTime(val && val.ctime || Date.now()));
 
           setupPopupBoxPinning(td, '.datum.popupbox', expIndex +',' + col);
+
+          // Set up a listener to onfocus trigger the animation on the warning element
+          // only if the datum has a saved value.
+          _.addEventListener(td, '.value', 'focus', function(ev){
+            var parentEl = ev.target.parentElement;
+            if (!parentEl.classList.contains('empty')) { // we have a saved value
+              var changeWarningEl = _.findEl(parentEl, '.changewarning');
+              changeWarningEl.classList.add('animated');
+            }
+          })
 
           // populate comments
           fillComments('comment-template', td, '.commentcount', '.datum.popupbox main', paper, ['experiments', expIndex, 'data', col, 'comments']);

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -14,7 +14,7 @@
   <a href="/" id="logo-box">
     <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
   </a>
-  
+
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">
@@ -375,6 +375,8 @@
           <span class="valctime date">error</span>
           by
           <a class="valenteredby" href="error">error</a>
+        </p>
+        <p class="changewarning notcomputed">
         </p>
         <p class="notcomputed"><span class="commentcount"></span> comment(s):</p>
       </header>

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -14,7 +14,7 @@
   <a href="/" id="logo-box">
     <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
   </a>
-
+  
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">
@@ -377,6 +377,7 @@
           <a class="valenteredby" href="error">error</a>
         </p>
         <p class="changewarning notcomputed">
+          When updating an existing value, consider leaving a comment justifying the change.
         </p>
         <p class="notcomputed"><span class="commentcount"></span> comment(s):</p>
       </header>

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -14,7 +14,7 @@
   <a href="/" id="logo-box">
     <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
   </a>
-
+  
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">
@@ -319,6 +319,7 @@
           <a class="valenteredby" href="error">error</a>
         </p>
         <p class="changewarning notcomputed">
+          When updating an existing value, consider leaving a comment justifying the change.
         </p>
         <p class="notcomputed"><span class="commentcount"></span> comments:</p>
       </header>

--- a/webpages/profile/paper.html
+++ b/webpages/profile/paper.html
@@ -14,7 +14,7 @@
   <a href="/" id="logo-box">
     <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
   </a>
-  
+
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">
@@ -317,6 +317,8 @@
           <span class="valctime date">error</span>
           by
           <a class="valenteredby" href="error">error</a>
+        </p>
+        <p class="changewarning notcomputed">
         </p>
         <p class="notcomputed"><span class="commentcount"></span> comments:</p>
       </header>


### PR DESCRIPTION
When the user focuses on a datum which is not empty, change
the class of the changewarning field to re-trigger the animation.

The warning will pulse once from black -> red -> black.

In addition, populate this warning box on page load ONLY if the
datum is not empty, to prevent any wierd popping from focus/unfocus.