### PR TITLE
Forest plot: Add grouping.

### DIFF
--- a/webpages/js/formulas.js
+++ b/webpages/js/formulas.js
@@ -238,13 +238,13 @@
         id: 'forestPlotPercentAggr',
         label: 'Forest Plot (percentages)',
         func: forestPlotPercentAggr,
-        parameters: [ 'group 1 (e.g. experimental percentage)', 'group 1 N', 'group 2 (e.g. control percentage)', 'group 2 N' ],
+        parameters: [ 'group 1 (e.g. experimental percentage)', 'group 1 N', 'group 2 (e.g. control percentage)', 'group 2 N', 'moderator' ],
       },
       {
         id: 'forestPlotNumberAggr',
         label: 'Forest Plot (numbers affected)',
         func: forestPlotNumberAggr,
-        parameters: [ 'group 1 (e.g. experimental affected)', 'group 1 N', 'group 2 (e.g. control affected)', 'group 2 N' ],
+        parameters: [ 'group 1 (e.g. experimental affected)', 'group 1 N', 'group 2 (e.g. control affected)', 'group 2 N', 'moderator' ],
       },
       {
         id: 'grapeChartPercentAggr',

--- a/webpages/js/formulas.js
+++ b/webpages/js/formulas.js
@@ -238,12 +238,24 @@
         id: 'forestPlotPercentAggr',
         label: 'Forest Plot (percentages)',
         func: forestPlotPercentAggr,
-        parameters: [ 'group 1 (e.g. experimental percentage)', 'group 1 N', 'group 2 (e.g. control percentage)', 'group 2 N', 'moderator' ],
+        parameters: [ 'group 1 (e.g. experimental percentage)', 'group 1 N', 'group 2 (e.g. control percentage)', 'group 2 N'],
       },
       {
         id: 'forestPlotNumberAggr',
         label: 'Forest Plot (numbers affected)',
         func: forestPlotNumberAggr,
+        parameters: [ 'group 1 (e.g. experimental affected)', 'group 1 N', 'group 2 (e.g. control affected)', 'group 2 N'],
+      },
+      {
+        id: 'forestPlotGroupPercentAggr',
+        label: 'Forest Plot Group (percentages)',
+        func: forestPlotGroupPercentAggr,
+        parameters: [ 'group 1 (e.g. experimental percentage)', 'group 1 N', 'group 2 (e.g. control percentage)', 'group 2 N', 'moderator' ],
+      },
+      {
+        id: 'forestPlotGroupNumberAggr',
+        label: 'Forest Plot Group (numbers affected)',
+        func: forestPlotGroupNumberAggr,
         parameters: [ 'group 1 (e.g. experimental affected)', 'group 1 N', 'group 2 (e.g. control affected)', 'group 2 N', 'moderator' ],
       },
       {
@@ -329,10 +341,16 @@
   function forestPlotPercentAggr () {
     return 'see above';
   }
+  function forestPlotGroupPercentAggr () {
+    return 'see above';
+  }
   function grapeChartPercentAggr () {
     return 'see above';
   }
   function forestPlotNumberAggr () {
+    return 'see above';
+  }
+  function forestPlotGroupNumberAggr () {
     return 'see above';
   }
   function grapeChartNumberAggr () {

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -668,6 +668,7 @@
       };
 
       var groupMembers = 0; // counter
+      var hasInvalid = false;
 
       var forestGroupT = _.findEl(plotEl, 'template.forest-group');
       var forestGroupEl = _.cloneTemplate(forestGroupT);
@@ -708,6 +709,7 @@
             groupAggregates.ucl += line.ucl;
           } else {
             expEl.classList.add('invalid');
+            hasInvalid = true;
           }
 
           groupExperimentsEl.appendChild(expEl);
@@ -722,7 +724,7 @@
       }
 
       // put group summary into the plot
-      if (!isNaN(aggregates.or*0)) {
+      if (!hasInvalid) {
         var sumT = _.findEl(plotEl, 'template.group-summary');
         var sumEl = _.cloneTemplate(sumT);
 
@@ -750,8 +752,8 @@
         groupSummaryEl.appendChild(sumEl);
 
         currGY += parseInt(plotEl.dataset.lineHeight);
-        currY += (currGY+ 50); // 10 + 30 for the missed first element, since we reset to 10 10 for spacing.
       }
+      currY += (currGY+ 50); // 10 + 30 for the missed first element, since we reset to 10 10 for spacing.
     })
 
 

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -680,7 +680,8 @@
       var groupAggregates = {
         or: 0,
         lcl: 0,
-        ucl: 0
+        ucl: 0,
+        wt: 0
       };
 
       var groupMembers = 0; // counter
@@ -709,9 +710,7 @@
           _.fillEls(expEl, '.expname', line.title);
           if (line.or != null) {
             groupMembers += 1;
-            _.fillEls(expEl, '.or', Math.exp(line.or).toPrecision(3));
-            _.fillEls(expEl, '.lcl', "" + Math.exp(line.lcl).toPrecision(3) + ",");
-            _.fillEls(expEl, '.ucl', Math.exp(line.ucl).toPrecision(3));
+            _.fillEls(expEl, '.or.lcl.ucl', Math.exp(line.or).toPrecision(3) + ' [' + Math.exp(line.lcl).toPrecision(3) + ", " + Math.exp(line.ucl).toPrecision(3) + ']');
             _.fillEls(expEl, '.wt', '' + (Math.round(line.wt / sumOfWt * 1000)/10) + '%');
             _.fillEls(expEl, '.wtg', ', ' + (Math.round(line.wtg)/10) + '%');
             _.setAttrs(expEl, 'line.confidenceinterval', 'x1', getX(line.lcl));
@@ -724,6 +723,7 @@
             groupAggregates.or += line.or;
             groupAggregates.lcl += line.lcl;
             groupAggregates.ucl += line.ucl;
+            groupAggregates.wt += (Math.round(line.wt / sumOfWt * 1000)/10);
           } else {
             expEl.classList.add('invalid');
             hasInvalid = true;
@@ -736,9 +736,18 @@
         }
       });
 
-      // divide the groupAggregate sums by the number of valid lines in the group.
+      // if stat != wt, then divide the groupAggregate sums by the number of valid lines in the group.
       for (var stat in groupAggregates) {
-        groupAggregates[stat] /= groupMembers;
+        if (stat != "wt") {
+          groupAggregates[stat] /= groupMembers;
+        }
+        else {
+          // avoid having too much decimals
+          var splitNumber = (groupAggregates[stat] + "").split(".");
+          if(splitNumber.length == 2 && splitNumber[1].length > 1) {
+            groupAggregates[stat] = Math.round(groupAggregates[stat]*10)/10;
+          }
+        }
       }
 
       // put group summary into the plot
@@ -749,9 +758,8 @@
         _.fillEls(sumEl, '.sumname', "Total for " + group);
         sumEl.setAttribute('transform', 'translate(' + plotEl.dataset.groupLineOffset + ',' + currGY + ')');
 
-        _.fillEls(sumEl, '.or', Math.exp(groupAggregates.or).toPrecision(3));
-        _.fillEls(sumEl, '.lcl', "" + Math.exp(groupAggregates.lcl).toPrecision(3) + ",");
-        _.fillEls(sumEl, '.ucl', Math.exp(groupAggregates.ucl).toPrecision(3));
+        _.fillEls(sumEl, '.or.lcl.ucl', Math.exp(groupAggregates.or).toPrecision(3) + ' [' + Math.exp(groupAggregates.lcl).toPrecision(3) + ", " + Math.exp(groupAggregates.ucl).toPrecision(3) + ']');
+        _.fillEls(sumEl, '.wt', groupAggregates.wt + '%');
 
         var lclX = getX(groupAggregates.lcl);
         var uclX = getX(groupAggregates.ucl);
@@ -809,9 +817,7 @@
 
       sumEl.setAttribute('transform', 'translate(' + plotEl.dataset.padding + ',' + currY + ')');
 
-      _.fillEls(sumEl, '.or', Math.exp(aggregates.or).toPrecision(3));
-      _.fillEls(sumEl, '.lcl', "" + Math.exp(aggregates.lcl).toPrecision(3) + ",");
-      _.fillEls(sumEl, '.ucl', Math.exp(aggregates.ucl).toPrecision(3));
+      _.fillEls(sumEl, '.or.lcl.ucl', Math.exp(aggregates.or).toPrecision(3) + ' [' + Math.exp(aggregates.lcl).toPrecision(3) + ", " + Math.exp(aggregates.ucl).toPrecision(3) + ']');
 
       var lclX = getX(aggregates.lcl);
       var uclX = getX(aggregates.ucl);

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -563,11 +563,6 @@
       perGroup[dataGroup[0].group].or = dataGroup.reduce(function sumproduct(acc, line) {return line.wt != null ? acc+line.or*line.wt : acc;}, 0) / perGroup[dataGroup[0].group].wt;
     });
 
-    // todo highlight the current experiment in forest plot and in grape chart
-    // set chart width based on number of groups
-    plotEl.setAttribute('width', parseInt(plotEl.dataset.zeroGroupsWidth) + groups.length * parseInt(plotEl.dataset.groupSpacing));
-    plotEl.setAttribute('viewBox', "0 0 " + plotEl.getAttribute('width') + " " + plotEl.getAttribute('height'));
-
     var orAggrFunc = { formulaName: "weightedMeanAggr", formulaParams: [ orFunc, wtFunc ] };
     var lclAggrFunc = { formulaName: "lowerConfidenceLimitAggr", formulaParams: [ orFunc, wtFunc ] };
     var uclAggrFunc = { formulaName: "upperConfidenceLimitAggr", formulaParams: [ orFunc, wtFunc ] };
@@ -673,7 +668,7 @@
     }
 
     var currY = parseInt(plotEl.dataset.startHeight);
-    var currGY = 10;
+    var currGY = parseInt(plotEl.dataset.groupStartHeight);
     var hasInvalid = false;
 
     groups.forEach(function (group) {
@@ -690,7 +685,7 @@
       var forestGroupT = _.findEl(plotEl, 'template.forest-group');
       var forestGroupEl = _.cloneTemplate(forestGroupT);
 
-      currGY = 10;
+      currGY = parseInt(plotEl.dataset.groupStartHeight);
 
       forestGroupEl.setAttribute('transform', 'translate(' + plotEl.dataset.headingOffset + ',' + currY + ')');
 
@@ -712,7 +707,7 @@
             groupMembers += 1;
             _.fillEls(expEl, '.or.lcl.ucl', Math.exp(line.or).toPrecision(3) + ' [' + Math.exp(line.lcl).toPrecision(3) + ", " + Math.exp(line.ucl).toPrecision(3) + ']');
             _.fillEls(expEl, '.wt', '' + (Math.round(line.wt / sumOfWt * 1000)/10) + '%');
-            _.fillEls(expEl, '.wtg', ', ' + (Math.round(line.wtg)/10) + '%');
+            _.fillEls(expEl, '.wtg', (Math.round(line.wtg)/10) + '%');
             _.setAttrs(expEl, 'line.confidenceinterval', 'x1', getX(line.lcl));
             _.setAttrs(expEl, 'line.confidenceinterval', 'x2', getX(line.ucl));
 
@@ -743,10 +738,7 @@
         }
         else {
           // avoid having too much decimals
-          var splitNumber = (groupAggregates[stat] + "").split(".");
-          if(splitNumber.length == 2 && splitNumber[1].length > 1) {
-            groupAggregates[stat] = Math.round(groupAggregates[stat]*10)/10;
-          }
+          groupAggregates[stat] = groupAggregates[stat].toFixed(1);
         }
       }
 
@@ -779,7 +771,7 @@
 
         currGY += parseInt(plotEl.dataset.lineHeight);
       }
-      currY += (currGY+ 50); // 10 + 30 for the missed first element, since we reset to 10 10 for spacing.
+      currY += (currGY+ parseInt(plotEl.dataset.heightBetweenGroups));
     })
 
 

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -412,6 +412,7 @@
     setUnsavedClass();
 
     addComputedDatumSetter(drawForestPlot);
+    addComputedDatumSetter(drawForestPlotGroup);
     addComputedDatumSetter(drawGrapeChart);
 
     recalculateComputedData();
@@ -446,7 +447,7 @@
     //     lcl
     //     ucl
 
-    var orFunc, wtFunc, lclFunc, uclFunc, moderatorParam, params;
+    var orFunc, wtFunc, lclFunc, uclFunc, params;
 
     // todo the plot should be associated with its parameters differently, not through an aggregate
     // todo there should be the possibility to have more forest plots
@@ -457,10 +458,307 @@
         wtFunc = { formulaName: "weightNumber", formulaParams: params };
         lclFunc = { formulaName: "lowerConfidenceLimitNumber", formulaParams: params };
         uclFunc = { formulaName: "upperConfidenceLimitNumber", formulaParams: params };
-        moderatorParam = params[4];
         break;
       }
       if (currentMetaanalysis.aggregates[i].formulaName === 'forestPlotPercentAggr' && isColCompletelyDefined(currentMetaanalysis.aggregates[i])) {
+        params = currentMetaanalysis.aggregates[i].formulaParams;
+        orFunc = { formulaName: "logOddsRatioPercent", formulaParams: [params[0], params[2]] };
+        wtFunc = { formulaName: "weightPercent", formulaParams: params };
+        lclFunc = { formulaName: "lowerConfidenceLimitPercent", formulaParams: params };
+        uclFunc = { formulaName: "upperConfidenceLimitPercent", formulaParams: params };
+        break;
+      }
+    }
+
+    if (i === currentMetaanalysis.aggregates.length) {
+     // we don't have any parameters for the forestPlot
+      return;
+    }
+
+    var plotsContainer = _.findEl('#metaanalysis > .plots');
+    plotsContainer.innerHTML = '';
+
+    var plotEl = _.cloneTemplate('forest-plot-template').children[0];
+    plotEl.classList.toggle('maximized', !!localStorage.plotMaximized);
+
+    // get the data
+    orFunc.formula = lima.createFormulaString(orFunc);
+    wtFunc.formula = lima.createFormulaString(wtFunc);
+    lclFunc.formula = lima.createFormulaString(lclFunc);
+    uclFunc.formula = lima.createFormulaString(uclFunc);
+
+    var lines=[];
+
+    for (i=0; i<currentMetaanalysis.papers.length; i+=1) {
+      for (var j=0; j<currentMetaanalysis.papers[i].experiments.length; j+=1) {
+        if (isExcludedExp(currentMetaanalysis.papers[i].id, j)) continue;
+        var line = {};
+        line.title = currentMetaanalysis.papers[i].title || 'new paper';
+        if (currentMetaanalysis.papers[i].experiments.length > 1) {
+          var expTitle = currentMetaanalysis.papers[i].experiments[j].title || 'new experiment';
+          if (expTitle.match(/^\d+$/)) expTitle = 'Exp. ' + expTitle;
+          line.title += ' (' + expTitle + ')';
+        }
+        line.or = getDatumValue(orFunc, j, i);
+        line.wt = getDatumValue(wtFunc, j, i);
+        line.lcl = getDatumValue(lclFunc, j, i);
+        line.ucl = getDatumValue(uclFunc, j, i);
+        lines.push(line);
+
+        // if any of the values is NaN or ±Infinity, disregard this experiment
+        if (isNaN(line.or*0) || isNaN(line.lcl*0) || isNaN(line.ucl*0) || isNaN(line.wt*0) ||
+           line.or == null || line.lcl == null || line.ucl == null || line.wt == null) {
+          delete line.or;
+          delete line.lcl;
+          delete line.ucl;
+          delete line.wt;
+        }
+      }
+    }
+
+    // add indication to the graph when there is no data
+    if (lines.length === 0) {
+      var noDataLine = {title: "No data"};
+      lines.push(noDataLine);
+    }
+
+    var orAggrFunc = { formulaName: "weightedMeanAggr", formulaParams: [ orFunc, wtFunc ] };
+    var lclAggrFunc = { formulaName: "lowerConfidenceLimitAggr", formulaParams: [ orFunc, wtFunc ] };
+    var uclAggrFunc = { formulaName: "upperConfidenceLimitAggr", formulaParams: [ orFunc, wtFunc ] };
+
+    orAggrFunc.formula = lima.createFormulaString(orAggrFunc);
+    lclAggrFunc.formula = lima.createFormulaString(lclAggrFunc);
+    uclAggrFunc.formula = lima.createFormulaString(uclAggrFunc);
+
+    var aggregates = {
+      or: getDatumValue(orAggrFunc),
+      lcl: getDatumValue(lclAggrFunc),
+      ucl: getDatumValue(uclAggrFunc),
+    }
+
+    if (isNaN(aggregates.or*0) || isNaN(aggregates.lcl*0) || isNaN(aggregates.ucl*0)) {
+      aggregates.lcl = 0;
+      aggregates.ucl = 0;
+    }
+
+    // compute
+    //   sum of wt
+    //   min and max of wt
+    //   min of lcl and aggr lcl
+    //   max of ucl and aggr ucl
+    var sumOfWt = 0;
+    var minWt = Infinity;
+    var maxWt = -Infinity;
+    var minLcl = aggregates.lcl;
+    var maxUcl = aggregates.ucl;
+
+    if (isNaN(minLcl)) minLcl = 0;
+    if (isNaN(maxUcl)) maxUcl = 0;
+
+    lines.forEach(function (line) {
+      if (line.or == null) return;
+      sumOfWt += line.wt;
+      if (line.wt < minWt) minWt = line.wt;
+      if (line.wt > maxWt) maxWt = line.wt;
+      if (line.lcl < minLcl) minLcl = line.lcl;
+      if (line.ucl > maxUcl) maxUcl = line.ucl;
+    });
+
+    if (minLcl < -10) minLcl = -10;
+    if (maxUcl > 10) maxUcl = 10;
+
+    if (minWt == Infinity) minWt = maxWt = 1;
+    if (sumOfWt == 0) sumOfWt = 1;
+
+    var TICK_SPACING;
+
+
+    // select tick spacing based on a rough estimate of how many ticks we'll need anyway
+    var clSpread = (maxUcl - minLcl) / Math.LN10; // how many orders of magnitude we cover
+    if (clSpread > 3) TICK_SPACING = [100];
+    else if (clSpread > 1.3) TICK_SPACING = [10];
+    else TICK_SPACING = [ 2, 2.5, 2 ]; // ticks at 1, 2, 5, 10, 20, 50, 100...
+
+
+    // adjust minimum and maximum around decimal non-logarithmic values
+    var newBound = 1;
+    var tickNo = 0;
+    while (Math.log(newBound) > minLcl) {
+      tickNo -= 1;
+      newBound /= TICK_SPACING[_.mod(tickNo, TICK_SPACING.length)]; // JS % can be negative
+    }
+    minLcl = Math.log(newBound) - .1;
+
+    var startingTickVal = newBound;
+    var startingTick = tickNo;
+
+    newBound = 1;
+    tickNo = 0;
+    while (Math.log(newBound) < maxUcl) {
+      newBound *= TICK_SPACING[_.mod(tickNo, TICK_SPACING.length)];
+      tickNo += 1;
+    }
+    maxUcl = Math.log(newBound) + .1;
+
+    var xRatio = 1/(maxUcl-minLcl)*parseInt(plotEl.dataset.graphWidth);
+
+    // return the X coordinate on the graph that corresponds to the given logarithmic value
+    function getX(val) {
+      return (val-minLcl)*xRatio;
+    }
+
+    // adjust weights so that in case of very similar weights they don't range from minimum to maximum
+    var MIN_WT_SPREAD=2.5;
+    if (maxWt/minWt < MIN_WT_SPREAD) {
+      minWt = (maxWt + minWt) / 2 / Math.sqrt(MIN_WT_SPREAD);
+      maxWt = minWt * MIN_WT_SPREAD;
+    }
+
+    // minWt = 0; // todo we can uncomment this to make all weights relative to only the maximum weight
+    var minWtSize = parseInt(plotEl.dataset.minWtSize);
+    // square root the weights because we're using them as lengths of the side of a square whose area should correspond to the weight
+    maxWt = Math.sqrt(maxWt);
+    minWt = Math.sqrt(minWt);
+    var wtRatio = 1/(maxWt-minWt)*(parseInt(plotEl.dataset.maxWtSize)-minWtSize);
+
+    // return the box size for a given weight
+    function getBoxSize(wt) {
+      return (Math.sqrt(wt)-minWt)*wtRatio + minWtSize;
+    }
+
+    var currY = parseInt(plotEl.dataset.startHeight);
+
+    // put experiments into the plot
+    lines.forEach(function (line) {
+      var expT = _.findEl(plotEl, 'template.experiment');
+      var expEl = _.cloneTemplate(expT);
+
+      expEl.setAttribute('transform', 'translate(' + plotEl.dataset.padding + ',' + currY + ')');
+
+      _.fillEls(expEl, '.expname', line.title);
+      if (line.or != null) {
+        _.fillEls(expEl, '.or', Math.exp(line.or).toPrecision(3));
+        _.fillEls(expEl, '.lcl', "" + Math.exp(line.lcl).toPrecision(3) + ",");
+        _.fillEls(expEl, '.ucl', Math.exp(line.ucl).toPrecision(3));
+        _.fillEls(expEl, '.wt', '' + (Math.round(line.wt / sumOfWt * 1000)/10) + '%');
+
+        _.setAttrs(expEl, 'line.confidenceinterval', 'x1', getX(line.lcl));
+        _.setAttrs(expEl, 'line.confidenceinterval', 'x2', getX(line.ucl));
+
+        _.setAttrs(expEl, 'rect.weightbox', 'x', getX(line.or));
+        _.setAttrs(expEl, 'rect.weightbox', 'width', getBoxSize(line.wt));
+        _.setAttrs(expEl, 'rect.weightbox', 'height', getBoxSize(line.wt));
+      } else {
+        expEl.classList.add('invalid');
+      }
+
+      expT.parentElement.insertBefore(expEl, expT);
+
+      currY += parseInt(plotEl.dataset.lineHeight);
+    })
+
+
+
+    // put summary into the plot
+    if (!isNaN(aggregates.or*0)) {
+      var sumT = _.findEl(plotEl, 'template.summary');
+      var sumEl = _.cloneTemplate(sumT);
+
+      sumEl.setAttribute('transform', 'translate(' + plotEl.dataset.padding + ',' + currY + ')');
+
+      _.fillEls(sumEl, '.or', Math.exp(aggregates.or).toPrecision(3));
+      _.fillEls(sumEl, '.lcl', "" + Math.exp(aggregates.lcl).toPrecision(3) + ",");
+      _.fillEls(sumEl, '.ucl', Math.exp(aggregates.ucl).toPrecision(3));
+
+      var lclX = getX(aggregates.lcl);
+      var uclX = getX(aggregates.ucl);
+      var orX = getX(aggregates.or);
+      if ((uclX - lclX) < parseInt(plotEl.dataset.minDiamondWidth)) {
+        var ratio = (uclX - lclX) / parseInt(plotEl.dataset.minDiamondWidth);
+        lclX = orX + (lclX - orX) / ratio;
+        uclX = orX + (uclX - orX) / ratio;
+      }
+
+      var confidenceInterval = "" + lclX + ",0 " + orX + ",-10 " + uclX + ",0 " + orX + ",10";
+
+      _.setAttrs(sumEl, 'polygon.confidenceinterval', 'points', confidenceInterval);
+
+      _.setAttrs(sumEl, 'line.guideline', 'x1', getX(aggregates.or));
+      _.setAttrs(sumEl, 'line.guideline', 'x2', getX(aggregates.or));
+      _.setAttrs(sumEl, 'line.guideline', 'y2', currY+parseInt(plotEl.dataset.lineHeight)+parseInt(plotEl.dataset.extraLineLen));
+
+      sumT.parentElement.insertBefore(sumEl, sumT);
+      currY += parseInt(plotEl.dataset.lineHeight);
+    }
+
+
+    // put axes into the plot
+    var axesT = _.findEl(plotEl, 'template.axes');
+    var axesEl = _.cloneTemplate(axesT);
+
+    axesEl.setAttribute('transform', 'translate(' + plotEl.dataset.padding + ',' + currY + ')');
+
+    _.setAttrs(axesEl, 'line.yaxis', 'y2', currY+parseInt(plotEl.dataset.extraLineLen));
+    _.setAttrs(axesEl, 'line.yaxis', 'x1', getX(0));
+    _.setAttrs(axesEl, 'line.yaxis', 'x2', getX(0));
+
+    var tickT = _.findEl(axesEl, 'template.tick');
+    var tickVal;
+    while ((tickVal = Math.log(startingTickVal)) < maxUcl) {
+      var tickEl = _.cloneTemplate(tickT);
+      tickEl.setAttribute('transform', 'translate(' + getX(tickVal) + ',0)');
+      _.fillEls(tickEl, 'text', (tickVal < 0 ? startingTickVal.toPrecision(1) : Math.round(startingTickVal)));
+      tickT.parentElement.insertBefore(tickEl, tickT);
+      startingTickVal = startingTickVal * TICK_SPACING[_.mod(startingTick, TICK_SPACING.length)];
+      startingTick += 1;
+    }
+
+    axesT.parentElement.insertBefore(axesEl, axesT);
+
+    _.addEventListener(axesEl, '.positioningbutton', 'click', function (e) {
+      plotEl.classList.toggle('maximized');
+      localStorage.plotMaximized = plotEl.classList.contains('maximized') ? '1' : '';
+      e.stopPropagation();
+    })
+
+    plotEl.setAttribute('height', parseInt(plotEl.dataset.endHeight) + currY);
+    plotEl.setAttribute('viewBox', "0 0 " + plotEl.getAttribute('width') + " " + plotEl.getAttribute('height'));
+    // todo set plot widths based on maximum text sizes
+
+    plotsContainer.appendChild(plotEl);
+  }
+
+  function drawForestPlotGroup() {
+    // prepare data:
+    // first find the forestPlot aggregate, it gives us the parameters
+    // then for every paper and every experiment, call appropriate functions to get or,lcl,ucl,wt
+    // then get the aggregates or,lcl,ucl
+    //   lines (array)
+    //     title (paper and maybe experiment)
+    //     or
+    //     lcl
+    //     ucl
+    //     wt
+    //   aggregated
+    //     or
+    //     lcl
+    //     ucl
+
+    var orFunc, wtFunc, lclFunc, uclFunc, moderatorParam, params;
+
+    // todo the plot should be associated with its parameters differently, not through an aggregate
+    // todo there should be the possibility to have more forest plots
+    for (var i=0; i<currentMetaanalysis.aggregates.length; i++) {
+      if (currentMetaanalysis.aggregates[i].formulaName === 'forestPlotGroupNumberAggr' && isColCompletelyDefined(currentMetaanalysis.aggregates[i])) {
+        params = currentMetaanalysis.aggregates[i].formulaParams;
+        orFunc = { formulaName: "logOddsRatioNumber", formulaParams: params };
+        wtFunc = { formulaName: "weightNumber", formulaParams: params };
+        lclFunc = { formulaName: "lowerConfidenceLimitNumber", formulaParams: params };
+        uclFunc = { formulaName: "upperConfidenceLimitNumber", formulaParams: params };
+        moderatorParam = params[4];
+        break;
+      }
+      if (currentMetaanalysis.aggregates[i].formulaName === 'forestPlotGroupPercentAggr' && isColCompletelyDefined(currentMetaanalysis.aggregates[i])) {
         params = currentMetaanalysis.aggregates[i].formulaParams;
         orFunc = { formulaName: "logOddsRatioPercent", formulaParams: [params[0], params[2]] };
         wtFunc = { formulaName: "weightPercent", formulaParams: params };
@@ -479,7 +777,7 @@
     var plotsContainer = _.findEl('#metaanalysis > .plots');
     plotsContainer.innerHTML = '';
 
-    var plotEl = _.cloneTemplate('forest-plot-template').children[0];
+    var plotEl = _.cloneTemplate('forest-plot-group-template').children[0];
     plotEl.classList.toggle('maximized', !!localStorage.plotMaximized);
 
     // get the data

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -533,11 +533,26 @@
 
     groups.sort(); // alphabetically
 
+    // calculating wtg
+    groups.forEach(function (group) {
+      var sumOfWtg = 0;
+      lines.forEach(function (line) {
+        if (line.group == group) {
+          sumOfWtg += line.wt;
+        }
+      });
+
+      lines.forEach(function (line) {
+        if (line.group == group) {
+          line.wtg = line.wt / sumOfWtg * 1000;
+        }
+      });
+    });
+
     var dataGroups =
       groups.map(function (group) {
         return lines.filter(function (exp) { return exp.group == group; });
       });
-
 
     // todo use per-group aggregates here
     var perGroup = {};
@@ -698,6 +713,7 @@
             _.fillEls(expEl, '.lcl', "" + Math.exp(line.lcl).toPrecision(3) + ",");
             _.fillEls(expEl, '.ucl', Math.exp(line.ucl).toPrecision(3));
             _.fillEls(expEl, '.wt', '' + (Math.round(line.wt / sumOfWt * 1000)/10) + '%');
+            _.fillEls(expEl, '.wtg', ', ' + (Math.round(line.wtg)/10) + '%');
             _.setAttrs(expEl, 'line.confidenceinterval', 'x1', getX(line.lcl));
             _.setAttrs(expEl, 'line.confidenceinterval', 'x2', getX(line.ucl));
 

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -659,6 +659,7 @@
 
     var currY = parseInt(plotEl.dataset.startHeight);
     var currGY = 10;
+    var hasInvalid = false;
 
     groups.forEach(function (group) {
       var groupAggregates = {
@@ -668,7 +669,7 @@
       };
 
       var groupMembers = 0; // counter
-      var hasInvalid = false;
+      var groupHasInvalid = false;
 
       var forestGroupT = _.findEl(plotEl, 'template.forest-group');
       var forestGroupEl = _.cloneTemplate(forestGroupT);
@@ -710,6 +711,7 @@
           } else {
             expEl.classList.add('invalid');
             hasInvalid = true;
+            groupHasInvalid = true;
           }
 
           groupExperimentsEl.appendChild(expEl);
@@ -724,7 +726,7 @@
       }
 
       // put group summary into the plot
-      if (!hasInvalid) {
+      if (!groupHasInvalid) {
         var sumT = _.findEl(plotEl, 'template.group-summary');
         var sumEl = _.cloneTemplate(sumT);
 
@@ -784,7 +786,7 @@
 
 
     // put summary into the plot
-    if (!isNaN(aggregates.or*0)) {
+    if (!isNaN(aggregates.or*0) && !hasInvalid) {
       currY += 2 * parseInt(plotEl.dataset.lineHeight);
       var sumT = _.findEl(plotEl, 'template.summary');
       var sumEl = _.cloneTemplate(sumT);

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -536,6 +536,13 @@
         text-anchor: end;
       }
 
+      .headings text.wtg,
+      .experiment text.wtg,
+      .summary text.wtg {
+        transform: translate(780px,20px);
+        text-anchor: start;
+      }
+
       .experiment .expname {
         text-anchor: start;
         transform: translate(0,20px);
@@ -635,6 +642,7 @@
       <text class="lcl">LCL,</text>
       <text class="ucl">UCL</text>
       <text class="wt">WT</text>
+      <text class="wtg">, WTG</text>
     </g>
 
     <template class="experiment">
@@ -644,6 +652,7 @@
         <text class="lcl">n/a,</text>
         <text class="ucl">n/a</text>
         <text class="wt">n/a</text>
+        <text class="wtg">, n/a</text>
         <g class="rowgraph">
           <line class="confidenceinterval"/><!-- should get x1="lcl" x2="ucl" -->
           <rect class="weightbox"/><!-- should get x="or" width="wt" height="wt" -->

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -14,7 +14,7 @@
   <a href="/" id="logo-box">
     <h1>LiMA</h1><h2>Living Meta-Analysis</h2>
   </a>
-  
+
   <!-- this puts a sign-in button, and a sign-out link, in the page -->
   <div class="userinfo signedoff">
     <img src="/img/user.png" alt="user photo or icon" class="userphoto">
@@ -477,9 +477,14 @@
   <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
+    viewBox="0 0 800 20"
     width="800"
     height="200"
     version="1.1"
+    data-heading-offset="40"
+    data-group-line-offset="-30"
+    data-zero-groups-width="70"
+    data-group-spacing="800"
     data-line-height="30"
     data-padding="10"
     data-graph-width="300"
@@ -596,8 +601,8 @@
         transform: translate(0px, 5px) scale(1, -1);
       }
 
-      .positioningbutton {
-        transform: translate(495px, 17px);
+      .summary > g.positioningbutton {
+        transform: translate(800px, 55px);
         opacity: .2;
       }
 
@@ -612,6 +617,16 @@
 
       .positioningbutton line {
         stroke-width: 1.5px;
+      }
+
+      .forest-group .group-heading text.label {
+        font-weight: bold;
+        font-size: 120%;
+      }
+
+      .summary .sumname.sumtotal {
+        font-weight: bold;
+        font-size: 125%;
       }
     </style>
 
@@ -636,6 +651,20 @@
       </g>
     </template>
 
+    <template class="forest-group">
+      <g class="forest-group">
+        <g class="group-heading">
+          <text class="label">group</text>
+        </g>
+        <g class="group-experiments">
+        </g>
+          <g class="group-summary"><!-- should get transform="translate(padding,currY)" -->
+          </g>
+        </g>
+      </g>
+    <template/>
+
+
     <template class="axes">
       <g class="axes"><!-- should get transform="translate(padding,currY)" -->
         <g>
@@ -648,14 +677,6 @@
               <text>val</text>
             </g>
           </template>
-          <g class="positioningbutton">
-            <circle r="8"/>
-            <line x1="-5" y1="-5" x2="5" y2="5"/>
-            <line x1="5" y1="5" x2="4" y2="0"/>
-            <line x1="5" y1="5" x2="0" y2="4"/>
-            <line x1="-5" y1="-5" x2="-4" y2="0"/>
-            <line x1="-5" y1="-5" x2="0" y2="-4"/>
-          </g>
         </g>
       </g>
     </template>
@@ -663,7 +684,7 @@
     <template class="summary">
       <g class="summary"><!-- should get transform="translate(padding,currY)" -->
         <g>
-          <text class="sumname">Total</text>
+          <text class="sumname sumtotal">Total</text>
           <text class="or">err</text>
           <text class="lcl">err,</text>
           <text class="ucl">err</text>
@@ -672,8 +693,31 @@
             <polygon class="confidenceinterval"/><!-- should get points="lcl,0 or,-10 ucl,0 or,10" -->
           </g>
         </g>
+        <g class="positioningbutton">
+          <circle r="8"/>
+          <line x1="-5" y1="-5" x2="5" y2="5"/>
+          <line x1="5" y1="5" x2="4" y2="0"/>
+          <line x1="5" y1="5" x2="0" y2="4"/>
+          <line x1="-5" y1="-5" x2="-4" y2="0"/>
+          <line x1="-5" y1="-5" x2="0" y2="-4"/>
+        </g>
       </g>
     </template>
+
+    <template class="group-summary">
+      <g class="summary"><!-- should get transform="translate(padding,currY)" -->
+        <g>
+          <text class="sumname"></text>
+          <text class="or">err</text>
+          <text class="lcl">err,</text>
+          <text class="ucl">err</text>
+          <g class="sumgraph">
+            <polygon class="confidenceinterval"/><!-- should get points="lcl,0 or,-10 ucl,0 or,10" -->
+          </g>
+        </g>
+      </g>
+    </template>
+
 
   </svg>
 </template>

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -512,34 +512,23 @@
         text-anchor: middle;
       }
 
-      .headings text.or,
-      .experiment text.or,
-      .summary text.or {
-        transform: translate(610px,20px);
+      .headings text.or.lcl.ucl,
+      .experiment text.or.lcl.ucl,
+      .summary text.or.lcl.ucl {
+        transform: translate(610px, 20px);
       }
-      .headings text.lcl,
-      .experiment text.lcl,
-      .summary text.lcl {
-        text-anchor: end;
-        transform: translate(690px,20px);
-      }
-      .headings text.ucl,
-      .experiment text.ucl,
-      .summary text.ucl {
-        text-anchor: start;
-        transform: translate(695px,20px);
-      }
+
       .headings text.wt,
       .experiment text.wt,
       .summary text.wt {
-        transform: translate(780px,20px);
+        transform: translate(800px,20px);
         text-anchor: end;
       }
 
       .headings text.wtg,
       .experiment text.wtg,
       .summary text.wtg {
-        transform: translate(780px,20px);
+        transform: translate(800px,20px);
         text-anchor: start;
       }
 
@@ -638,9 +627,7 @@
     </style>
 
     <g transform="translate(10,0)" class="headings">
-      <text class="or">OR</text>
-      <text class="lcl">LCL,</text>
-      <text class="ucl">UCL</text>
+      <text class="or lcl ucl">OR [LCL, UCL]</text>
       <text class="wt">WT</text>
       <text class="wtg">, WTG</text>
     </g>
@@ -648,9 +635,7 @@
     <template class="experiment">
       <g class="experiment"><!-- should get transform="translate(padding,currY++)" -->
         <text class="expname">error</text>
-        <text class="or">invalid</text>
-        <text class="lcl">n/a,</text>
-        <text class="ucl">n/a</text>
+        <text class="or lcl ucl">invalid [n/a, n/a]</text>
         <text class="wt">n/a</text>
         <text class="wtg">, n/a</text>
         <g class="rowgraph">
@@ -694,9 +679,7 @@
       <g class="summary"><!-- should get transform="translate(padding,currY)" -->
         <g>
           <text class="sumname sumtotal">Total</text>
-          <text class="or">err</text>
-          <text class="lcl">err,</text>
-          <text class="ucl">err</text>
+          <text class="or lcl ucl">err [err, err]</text>
           <line class="guideline"/><!-- should get x1="or" x2="or" y2="currY+parseInt(plotEl.dataset.lineHeight)+parseInt(plotEl.dataset.extraLineLen)" -->
           <g class="sumgraph">
             <polygon class="confidenceinterval"/><!-- should get points="lcl,0 or,-10 ucl,0 or,10" -->
@@ -717,9 +700,8 @@
       <g class="summary"><!-- should get transform="translate(padding,currY)" -->
         <g>
           <text class="sumname"></text>
-          <text class="or">err</text>
-          <text class="lcl">err,</text>
-          <text class="ucl">err</text>
+          <text class="or lcl ucl">err [err, err]</text>
+          <text class="wt">err</text>
           <g class="sumgraph">
             <polygon class="confidenceinterval"/><!-- should get points="lcl,0 or,-10 ucl,0 or,10" -->
           </g>

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -480,6 +480,190 @@
     width="900"
     height="200"
     version="1.1"
+    data-line-height="30"
+    data-padding="10"
+    data-graph-width="300"
+    data-start-height="50"
+    data-end-height="65"
+    data-min-wt-size="4"
+    data-max-wt-size="14"
+    data-extra-line-len="-10"
+    data-min-diamond-width="14"
+    >
+    <style>
+      svg {
+        stroke-width: 2px;
+        fill: white;
+        stroke: black;
+        stroke-linecap: butt;
+        stroke-linejoin: miter;
+        font-size: 14px;
+        font-family: "Arial", sans-serif;
+      }
+      text {
+        stroke-width: 0;
+        fill: black;
+        text-anchor: middle;
+      }
+      .headings text.or,
+      .experiment text.or,
+      .summary text.or {
+        transform: translate(610px,20px);
+      }
+      .headings text.lcl,
+      .experiment text.lcl,
+      .summary text.lcl {
+        text-anchor: end;
+        transform: translate(690px,20px);
+      }
+      .headings text.ucl,
+      .experiment text.ucl,
+      .summary text.ucl {
+        text-anchor: start;
+        transform: translate(695px,20px);
+      }
+      .headings text.wt,
+      .experiment text.wt,
+      .summary text.wt {
+        transform: translate(780px,20px);
+        text-anchor: end;
+      }
+      .experiment .expname {
+        text-anchor: start;
+        transform: translate(0,20px);
+      }
+      .experiment.invalid text {
+        fill: #aa4444;
+      }
+      .experiment.invalid text.lcl,
+      .experiment.invalid text.ucl,
+      .experiment.invalid text.wt {
+        display: none;
+      }
+      .experiment .rowgraph {
+        transform: translate(280px,0);
+      }
+      .experiment .rowgraph .confidenceinterval {
+        transform: translate(0,15px);
+      }
+      .experiment .rowgraph .weightbox {
+        transform: translate(-50%,-50%) translate(0,15px);
+        fill: black;
+      }
+      .summary > g {
+        transform: translate(0, 20px);
+      }
+      .summary .sumname {
+        text-anchor: start;
+        transform: translate(0,20px);
+      }
+      .summary .sumgraph {
+        transform: translate(280px,0);
+      }
+      .summary .sumgraph .confidenceinterval {
+        transform: translate(0,15px);
+      }
+      .summary .guideline {
+        stroke-width: 1px;
+        transform: translate(280px,42.5px) scale(1,-1);
+        stroke-dasharray: 5px;
+        stroke-linecap: butt;
+      }
+      .axes > g {
+        transform: translate(280px,32.5px);
+      }
+      .axes .tick text {
+        font-size: 11px;
+        transform: translate(0, 19px);
+      }
+      .axes .yaxis {
+        transform: translate(0px, 5px) scale(1, -1);
+      }
+      .positioningbutton {
+        transform: translate(495px, 17px);
+        opacity: .2;
+      }
+      .positioningbutton:not(:hover) line {
+        display: none;
+      }
+      .positioningbutton:hover {
+        opacity: 1;
+        cursor: pointer;
+      }
+      .positioningbutton line {
+        stroke-width: 1.5px;
+      }
+    </style>
+
+    <g transform="translate(10,0)" class="headings">
+      <text class="or">OR</text>
+      <text class="lcl">LCL,</text>
+      <text class="ucl">UCL</text>
+      <text class="wt">WT</text>
+    </g>
+
+    <template class="experiment">
+      <g class="experiment"><!-- should get transform="translate(padding,currY++)" -->
+        <text class="expname">error</text>
+        <text class="or">invalid</text>
+        <text class="lcl">n/a,</text>
+        <text class="ucl">n/a</text>
+        <text class="wt">n/a</text>
+        <g class="rowgraph">
+          <line class="confidenceinterval"/><!-- should get x1="lcl" x2="ucl" -->
+          <rect class="weightbox"/><!-- should get x="or" width="wt" height="wt" -->
+        </g>
+      </g>
+    </template>
+
+    <template class="axes">
+      <g class="axes"><!-- should get transform="translate(padding,currY)" -->
+        <g>
+          <line class="yaxis"/><!-- should get x1="getX(0)" x2="getX(0)" y2="currY+parseInt(plotEl.dataset.extraLineLen)" -->
+          <line class="xaxis" x1="0" x2="300"/>
+          <!-- should get a number of ticks -->
+          <template class="tick">
+            <g class="tick"><!-- should get transform="translate(x,0)" -->
+              <line y2="5"/>
+              <text>val</text>
+            </g>
+          </template>
+          <g class="positioningbutton">
+            <circle r="8"/>
+            <line x1="-5" y1="-5" x2="5" y2="5"/>
+            <line x1="5" y1="5" x2="4" y2="0"/>
+            <line x1="5" y1="5" x2="0" y2="4"/>
+            <line x1="-5" y1="-5" x2="-4" y2="0"/>
+            <line x1="-5" y1="-5" x2="0" y2="-4"/>
+          </g>
+        </g>
+      </g>
+    </template>
+
+    <template class="summary">
+      <g class="summary"><!-- should get transform="translate(padding,currY)" -->
+        <g>
+          <text class="sumname">Total</text>
+          <text class="or">err</text>
+          <text class="lcl">err,</text>
+          <text class="ucl">err</text>
+          <line class="guideline"/><!-- should get x1="or" x2="or" y2="currY+parseInt(plotEl.dataset.lineHeight)+parseInt(plotEl.dataset.extraLineLen)" -->
+          <g class="sumgraph">
+            <polygon class="confidenceinterval"/><!-- should get points="lcl,0 or,-10 ucl,0 or,10" -->
+          </g>
+        </g>
+      </g>
+    </template>
+
+  </svg>
+</template>
+<template id="forest-plot-group-template">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="900"
+    height="200"
+    version="1.1"
     data-heading-offset="40"
     data-group-line-offset="-30"
     data-zero-groups-width="70"

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -477,18 +477,18 @@
   <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    viewBox="0 0 800 20"
-    width="800"
+    width="900"
     height="200"
     version="1.1"
     data-heading-offset="40"
     data-group-line-offset="-30"
     data-zero-groups-width="70"
-    data-group-spacing="800"
     data-line-height="30"
     data-padding="10"
-    data-graph-width="300"
+    data-graph-width="200"
     data-start-height="50"
+    data-group-start-height="10"
+    data-height-between-groups="50"
     data-end-height="65"
     data-min-wt-size="4"
     data-max-wt-size="14"
@@ -521,14 +521,14 @@
       .headings text.wt,
       .experiment text.wt,
       .summary text.wt {
-        transform: translate(800px,20px);
+        transform: translate(760px,20px);
         text-anchor: end;
       }
 
       .headings text.wtg,
       .experiment text.wtg,
       .summary text.wtg {
-        transform: translate(800px,20px);
+        transform: translate(780px,20px);
         text-anchor: start;
       }
 
@@ -629,7 +629,7 @@
     <g transform="translate(10,0)" class="headings">
       <text class="or lcl ucl">OR [LCL, UCL]</text>
       <text class="wt">WT</text>
-      <text class="wtg">, WTG</text>
+      <text class="wtg">WTG</text>
     </g>
 
     <template class="experiment">
@@ -637,7 +637,7 @@
         <text class="expname">error</text>
         <text class="or lcl ucl">invalid [n/a, n/a]</text>
         <text class="wt">n/a</text>
-        <text class="wtg">, n/a</text>
+        <text class="wtg">n/a</text>
         <g class="rowgraph">
           <line class="confidenceinterval"/><!-- should get x1="lcl" x2="ucl" -->
           <rect class="weightbox"/><!-- should get x="or" width="wt" height="wt" -->
@@ -656,7 +656,7 @@
           </g>
         </g>
       </g>
-    <template/>
+    </template>
 
 
     <template class="axes">


### PR DESCRIPTION
Includes some reworking of the svg to include group names and
group totals.

Multiple groups each have their own section and total, but the chart
overall only has one guideline (through all groups).

Positioning button moved to summary (from axes) as it is now the lowest element.