### PR TITLE
With aggregates, removed sometimes shown option none.

### DIFF
--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -2305,7 +2305,7 @@
       }
 
       // if the parameter is a computed value that isn't itself a column of the metaanalysis, add it as the last option
-      if (!foundCurrentValue) {
+      if (!foundCurrentValue && aggregate.formulaParams[i]) {
         colId = aggregate.formulaParams[i];
         makeOption(colId, aggregate, colId, select);
       }


### PR DESCRIPTION
This fixed is the same from computed columns, but was
missed here.