### PR TITLE
Align decimal

### DIFF
--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -1769,6 +1769,11 @@ body.page-about-you.editing .fullcolinfo header {
   padding-right: 23em; /* 15em for width of popupbox and 8em for width of overhanging column labels and new column box */
 }
 
+#metaanalysis table.aggregates td,  /* this catches grouping aggregates as well */
+#metaanalysis table.experiments td.computed {
+  text-align: right;
+}
+
 #paper table.experiments td span.value,
 #metaanalysis table.experiments td span.value {
   white-space: nowrap;

--- a/webpages/css/main.css
+++ b/webpages/css/main.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Gruppo|Raleway:300');
+@import url('https://fonts.googleapis.com/css?family=Gruppo|Raleway:300|Roboto:400,400i');
 
 body {
   font-family: "Arial", sans-serif;
@@ -1777,6 +1777,7 @@ body.page-about-you.editing .fullcolinfo header {
 #paper table.experiments td span.value,
 #metaanalysis table.experiments td span.value {
   white-space: nowrap;
+  font-family: "Roboto";
 }
 
 #paper.no-data table.experiments,
@@ -2635,6 +2636,29 @@ body.editing.page-about-you #metaanalysis table.experiments tr.row th.experiment
   padding-right: 1.5em; /* to give space to the "exclude" checkbox */
   padding-left: 1.5em; /* for symmetry */
 }
+
+#paper span.pad1,
+#metaanalysis span.pad1 {
+  padding-right: 1ch;
+}
+
+#paper span.pad2,
+#metaanalysis span.pad2 {
+  padding-right: 2ch;
+}
+
+#paper span.pad3dot,
+#metaanalysis span.pad3dot {
+  padding-right: 3ch;
+}
+
+#paper span.pad3dot:after,
+#metaanalysis span.pad3dot:after {
+  content: '.';
+  display: inline;
+  color: transparent;
+}
+
 
 /* aggregates
  *

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -1950,11 +1950,11 @@
                 td.classList.remove('empty');
               }
 
-              // only show three significant digits for numbers
-              if (typeof val == 'number') val = val.toPrecision(3);
+              var fullval = val;
+              if (typeof val == 'number') val = _.formatNumber(val);
 
               _.fillEls(td, '.value', val);
-
+              _.fillEls(td, '.fullvalue', fullval);
 
               // fill in information about where the value was computed from
               _.setProps(td, '.formula', 'innerHTML', getColTitle(col, Infinity));
@@ -3337,10 +3337,11 @@
           aggregateValTd.classList.remove('empty');
         }
 
-        // only show three significant digits for numbers
-        if (typeof val == 'number') val = val.toPrecision(3);
+        var fullval = val;
+        if (typeof val == 'number') val = _.formatNumber(val);
 
         _.fillEls(aggregateValTd, '.value', val);
+        _.fillEls(aggregateValTd, '.fullvalue', fullval);
       });
 
       fillAggregateInformation(aggregateEl, aggregate);
@@ -3592,10 +3593,11 @@
             td.classList.remove('empty');
           }
 
-          // only show three significant digits for numbers
-          if (typeof val == 'number') val = val.toPrecision(3);
+          var fullval = val;
+          if (typeof val == 'number') val = _.formatNumber(val);
 
           _.fillEls(td, '.value', val);
+          _.fillEls(td, '.fullvalue', fullval);
           _.fillEls(td, '.group', group);
 
           setupPopupBoxPinning(td, '.popupbox', groupingAggregate.formula + ',' + group);

--- a/webpages/js/metaanalyses.js
+++ b/webpages/js/metaanalyses.js
@@ -1950,11 +1950,8 @@
                 td.classList.remove('empty');
               }
 
-              var fullval = val;
-              if (typeof val == 'number') val = _.formatNumber(val);
-
-              _.fillEls(td, '.value', val);
-              _.fillEls(td, '.fullvalue', fullval);
+              _.fillPaddedValue(td, '.value', val);
+              _.fillEls(td, '.fullvalue', val);
 
               // fill in information about where the value was computed from
               _.setProps(td, '.formula', 'innerHTML', getColTitle(col, Infinity));
@@ -3337,11 +3334,8 @@
           aggregateValTd.classList.remove('empty');
         }
 
-        var fullval = val;
-        if (typeof val == 'number') val = _.formatNumber(val);
-
-        _.fillEls(aggregateValTd, '.value', val);
-        _.fillEls(aggregateValTd, '.fullvalue', fullval);
+        _.fillPaddedValue(aggregateValTd, '.value', val);
+        _.fillEls(aggregateValTd, '.fullvalue', val);
       });
 
       fillAggregateInformation(aggregateEl, aggregate);
@@ -3593,11 +3587,8 @@
             td.classList.remove('empty');
           }
 
-          var fullval = val;
-          if (typeof val == 'number') val = _.formatNumber(val);
-
-          _.fillEls(td, '.value', val);
-          _.fillEls(td, '.fullvalue', fullval);
+          _.fillPaddedValue(td, '.value', val);
+          _.fillEls(td, '.fullvalue', val);
           _.fillEls(td, '.group', group);
 
           setupPopupBoxPinning(td, '.popupbox', groupingAggregate.formula + ',' + group);

--- a/webpages/js/tools.js
+++ b/webpages/js/tools.js
@@ -618,6 +618,16 @@
 
   _.stripDOIPrefix = function (doi) { return _.stripPrefix('doi:', doi); };
 
+  // produce a presentable, not-too-high-precision string representation of a number
+  _.formatNumber = function formatNumber(x) {
+    if (typeof x !== 'number') return x;
+    var xabs = Math.abs(x);
+    if (xabs >= 100) return x.toFixed(0);
+    if (xabs >= 10) return x.toFixed(1);
+    if (xabs >= 1) return x.toFixed(2);
+    return x.toFixed(3);
+  };
+
 
   /* youOrName
    *
@@ -1041,6 +1051,59 @@
     assert(b.indexOf(3.5) == 2);
     assert(b.indexOf(4.1) == 2);
 
+  });
+
+  _.addTest(function testFormatNumber(assert) {
+    // use trimming so we can format the checks nicely
+    function check(num,str) {
+      assert(_.formatNumber(num) === str, 'error formatting ' + num + ', expecting ' + str + ' but got ' + _.formatNumber(num));
+    }
+
+    function check2(num,str) {
+      check(-num, '-' + str);
+    }
+
+
+    check (     Infinity,  'Infinity' );
+    check (     NaN     ,       'NaN' );
+    check (     0       ,     '0.000' );
+    check (    -0       ,     '0.000' );
+    check (     0.004   ,     '0.004' );
+    check (     0.0044  ,     '0.004' );
+    check (     0.004501,     '0.005' );   // 0.004501 because 0.0045 is actually 0.00449999999999999966
+    check (     0.0046  ,     '0.005' );
+    check (     0.005   ,     '0.005' );
+    check (     0.04    ,     '0.040' );
+    check (     0.14    ,     '0.140' );
+    check (     3.1     ,     '3.10'  );
+    check (     3.14    ,     '3.14'  );
+    check (    13.14    ,    '13.1'   );
+    check (   113.14    ,   '113'     );
+    check (  1113.14    ,  '1113'     );
+    check ( 11113.14    , '11113'     );
+
+    check2(     Infinity,  'Infinity' );
+    check2(     0.004   ,     '0.004' );
+    check2(     0.0044  ,     '0.004' );
+    check2(     0.004501,     '0.005' );   // 0.004501 because 0.0045 is actually 0.00449999999999999966
+    check2(     0.0046  ,     '0.005' );
+    check2(     0.005   ,     '0.005' );
+    check2(     0.04    ,     '0.040' );
+    check2(     0.14    ,     '0.140' );
+    check2(     3.1     ,     '3.10'  );
+    check2(     3.14    ,     '3.14'  );
+    check2(    13.14    ,    '13.1'   );
+    check2(   113.14    ,   '113'     );
+    check2(  1113.14    ,  '1113'     );
+    check2( 11113.14    , '11113'     );
+
+    check ('foo', 'foo');
+    check ('3', '3');
+    check (undefined, undefined);
+    check (null, null);
+
+    var a = {};
+    check (a, a);
   });
 
 

--- a/webpages/profile/metaanalysis.html
+++ b/webpages/profile/metaanalysis.html
@@ -394,7 +394,7 @@
     <div class="datum popupbox" data-boxtype='datumpopupbox'>
       <div class="pin"></div>
       <header>
-        <p class="value" placeholder="no value"></p>
+        <p class="fullvalue" placeholder="no value"></p>
         <p class="computed">
           calculated as
           <span class="formula"></span>
@@ -463,7 +463,7 @@
         <button class="when-unsaved down  " disabled title="can't move aggregate when some changes are unsaved"><span>»</span></button>
         <button class="when-unsaved down  " disabled title="can't move aggregate when some changes are unsaved"><span>»|</span></button>
         <header>
-          <p class="value" placeholder="no value">error</p>
+          <p class="fullvalue" placeholder="no value">error</p>
           <div class="aggregated">
             <p class="customaggrname">
               <span class="customaggrname" placeholder="optional custom name" contenteditable></span>
@@ -586,7 +586,7 @@
     <span class="value aggregated">error</span>
     <div class="datum popupbox" data-boxtype='datumpopupbox'>
       <header>
-        <p class="value" placeholder="no value"></p>
+        <p class="fullvalue" placeholder="no value"></p>
         <p>
           calculated for the <span class="group"></span> group as
           <span class="fullaggrlabel suppressgrouping"></span>


### PR DESCRIPTION
This expands the work started in #94, in this PR so we don't lose it.

This PR does the following:

- put high-precision value in popup box, lower-precision value in the data tables
- in the data tables, align right, pad from the right such that '.' is aligned
- use JS to find out how many chars follow the '.'.
- have a css class for each valid amount (0..n) and pad accordingly

It's a definite improvement on the status quo but still could be better. If the table has lots of large numbers, it will also have lots of blank space. This isn't a problem with a range of values, but when they are all large numbers there will be unnecessary padding. Trello has suggestions for further work.
